### PR TITLE
Add integration tests for parsers and stash service

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,84 @@
+name: test
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+    branches: [dev]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: './crates -> target'
+
+      - name: Run tests
+        run: cargo test --workspace --verbose
+
+  coverage:
+    name: Coverage Report
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: './crates -> target'
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Generate coverage report
+        run: cargo llvm-cov --workspace --html --output-dir target/coverage
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: target/coverage/
+          retention-days: 14
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: './crates -> target'
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,20 @@ env:
 
 jobs:
   test:
-    name: Run Tests
-    runs-on: ubuntu-latest
+    name: Run Tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -32,40 +42,21 @@ jobs:
       - name: Run tests
         run: cargo test --workspace --verbose
 
-  coverage:
-    name: Coverage Report
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: llvm-tools-preview
-
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: './crates -> target'
-
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
-
-      - name: Generate coverage report
-        run: cargo llvm-cov --workspace --html --output-dir target/coverage
-
-      - name: Upload coverage report
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-report
-          path: target/coverage/
-          retention-days: 14
-
   lint:
-    name: Lint
-    runs-on: ubuntu-latest
+    name: Lint (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,17 +43,12 @@ jobs:
         run: cargo test --workspace --verbose
 
   lint:
-    name: Lint (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+    name: Lint
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install system dependencies (Linux)
-        if: runner.os == 'Linux'
+      - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,9 @@ dependencies = [
  "log",
  "logger",
  "serde",
+ "serial_test",
  "tauri",
+ "tempfile",
  "tokio",
 ]
 
@@ -3749,6 +3751,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3813,6 +3824,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "seahash"
@@ -3992,6 +4009,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
  "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Makefile
+++ b/Makefile
@@ -70,16 +70,3 @@ clean: ## Clean build artifacts and dependencies
 test: ## Run all Rust tests
 	@echo "$(GREEN)Running Rust tests...$(NC)"
 	cargo test --workspace --verbose
-
-test-git: ## Run git crate tests only
-	@echo "$(GREEN)Running git crate tests...$(NC)"
-	cargo test -p git --verbose
-
-rust-coverage: ## Generate Rust test coverage report (HTML)
-	@echo "$(GREEN)Generating coverage report...$(NC)"
-	@cargo llvm-cov --workspace --html --output-dir target/coverage \
-		--ignore-filename-regex '(crates/ipc/|crates/logger/|apps/desktop/src-tauri/)'
-	@echo "$(GREEN)Coverage report generated at target/coverage/html/index.html$(NC)"
-
-rust-coverage-open: rust-coverage ## Generate and open coverage report
-	@open target/coverage/html/index.html

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup clean dev dev-vite build-vite build-tauri build format typegen test test-git rust-coverage rust-coverage-open
+.PHONY: help setup clean dev dev-vite build-vite build-tauri build format typegen test format-check clippy
 
 .DEFAULT_GOAL := help
 
@@ -70,3 +70,11 @@ clean: ## Clean build artifacts and dependencies
 test: ## Run all Rust tests
 	@echo "$(GREEN)Running Rust tests...$(NC)"
 	cargo test --workspace --verbose
+
+format-check: ## Check code formatting
+	@echo "$(YELLOW)Checking code formatting...$(NC)"
+	cargo fmt --all -- --check
+
+clippy: ## Run Clippy linter
+	@echo "$(YELLOW)Running Clippy linter...$(NC)"
+	cargo clippy --workspace --all-targets -- -D warnings

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup clean dev dev-vite build-vite build-tauri build format typegen
+.PHONY: help setup clean dev dev-vite build-vite build-tauri build format typegen test test-git rust-coverage rust-coverage-open
 
 .DEFAULT_GOAL := help
 
@@ -64,3 +64,22 @@ clean: ## Clean build artifacts and dependencies
 	@echo "$(RED)Cleaning build artifacts...$(NC)"
 	@./scripts/clear.sh
 	@echo "$(GREEN)Clean complete!$(NC)"
+
+##@ Testing
+
+test: ## Run all Rust tests
+	@echo "$(GREEN)Running Rust tests...$(NC)"
+	cargo test --workspace --verbose
+
+test-git: ## Run git crate tests only
+	@echo "$(GREEN)Running git crate tests...$(NC)"
+	cargo test -p git --verbose
+
+rust-coverage: ## Generate Rust test coverage report (HTML)
+	@echo "$(GREEN)Generating coverage report...$(NC)"
+	@cargo llvm-cov --workspace --html --output-dir target/coverage \
+		--ignore-filename-regex '(crates/ipc/|crates/logger/|apps/desktop/src-tauri/)'
+	@echo "$(GREEN)Coverage report generated at target/coverage/html/index.html$(NC)"
+
+rust-coverage-open: rust-coverage ## Generate and open coverage report
+	@open target/coverage/html/index.html

--- a/apps/desktop/src-tauri/src/commands/diff.rs
+++ b/apps/desktop/src-tauri/src/commands/diff.rs
@@ -18,5 +18,5 @@ pub async fn get_patch_by_file_path(
         .get_patch_by_file_path(file_path, stash_reference.as_deref())
         .await?;
 
-    return Ok(FileDiff { patch });
+    Ok(FileDiff { patch })
 }

--- a/apps/desktop/src/routes/app/git/index.tsx
+++ b/apps/desktop/src/routes/app/git/index.tsx
@@ -238,7 +238,7 @@ const DiffArea = ({ selectedFile }: { selectedFile: SelectedFile }) => {
   return (
     <div
       className={cn(
-        "max-h-[calc(100vh-calc(var(--spacing)*14)-calc(var(--spacing)*9)-calc(var(--spacing)*12)-calc(var(--spacing)*7))] h-full w-full relative overflow-y-auto bg-[color-mix(in_oklab,var(--color-secondary)_70%,var(--color-background))]",
+        "max-h-[calc(100vh-calc(var(--spacing)*14)-calc(var(--spacing)*9)-calc(var(--spacing)*12)-calc(var(--spacing)*6))] h-full w-full relative overflow-y-auto bg-[color-mix(in_oklab,var(--color-secondary)_70%,var(--color-background))]",
       )}
     >
       {isLoading ? (

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -17,11 +17,11 @@
       property="og:description"
       content="Gitru - A modern git client for humans."
     />
-    <meta property="og:image" content="https://gitru.ruru.build/og.png" />
+    <meta property="og:image" content="https://gitru.app/og.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Gitru - Waitlist" />
-    <meta property="og:url" content="https://gitru.ruru.build" />
+    <meta property="og:url" content="https://gitru.app" />
     <meta property="og:locale" content="en_US" />
     <meta property="og:type" content="website" />
 
@@ -31,7 +31,7 @@
       name="twitter:description"
       content="Gitru - A modern git client for humans."
     />
-    <meta name="twitter:image" content="https://gitru.ruru.build/og.png" />
+    <meta name="twitter:image" content="https://gitru.app/og.png" />
     <meta name="twitter:image:title" content="Gitru" />
     <meta name="twitter:image:alt" content="Gitru" />
     <meta name="twitter:image:width" content="1200" />

--- a/crates/git/Cargo.toml
+++ b/crates/git/Cargo.toml
@@ -14,3 +14,8 @@ log = "0.4"
 [lib]
 name = "git"
 path = "lib.rs"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full", "test-util", "macros"] }
+tempfile = "3"
+serial_test = "3"

--- a/crates/git/cache.rs
+++ b/crates/git/cache.rs
@@ -113,14 +113,14 @@ impl RepoCache {
                 .get(&storage_key)
                 .and_then(|entry| self.clone_typed::<T>(&entry.value));
 
-            if let Some(entry) = state.entries.get(&storage_key) {
-                if entry.is_fresh(now) {
-                    if let Some(value) = self.clone_typed::<T>(&entry.value) {
-                        log::debug!("cache hit key='{storage_key}'");
-                        return Ok(value);
-                    }
-                    state.entries.remove(&storage_key);
+            if let Some(entry) = state.entries.get(&storage_key)
+                && entry.is_fresh(now)
+            {
+                if let Some(value) = self.clone_typed::<T>(&entry.value) {
+                    log::debug!("cache hit key='{storage_key}'");
+                    return Ok(value);
                 }
+                state.entries.remove(&storage_key);
             }
 
             if let Some(inflight) = state.inflight.get(&storage_key) {

--- a/crates/git/cache.rs
+++ b/crates/git/cache.rs
@@ -116,7 +116,7 @@ impl RepoCache {
             if let Some(entry) = state.entries.get(&storage_key) {
                 if entry.is_fresh(now) {
                     if let Some(value) = self.clone_typed::<T>(&entry.value) {
-                        log::debug!("cache hit key='{}'", storage_key);
+                        log::debug!("cache hit key='{storage_key}'");
                         return Ok(value);
                     }
                     state.entries.remove(&storage_key);
@@ -124,12 +124,12 @@ impl RepoCache {
             }
 
             if let Some(inflight) = state.inflight.get(&storage_key) {
-                log::debug!("cache wait-inflight key='{}'", storage_key);
+                log::debug!("cache wait-inflight key='{storage_key}'");
                 (inflight.clone(), false, stale)
             } else {
                 let inflight = Arc::new(InFlight::new());
                 state.inflight.insert(storage_key.clone(), inflight.clone());
-                log::debug!("cache miss key='{}'", storage_key);
+                log::debug!("cache miss key='{storage_key}'");
                 (inflight, true, stale)
             }
         };
@@ -177,7 +177,7 @@ impl RepoCache {
                 }
 
                 inflight.notify.notify_waiters();
-                log::debug!("cache refresh-success key='{}'", storage_key);
+                log::debug!("cache refresh-success key='{storage_key}'");
                 Ok(value)
             }
             Err(err) => {
@@ -201,14 +201,12 @@ impl RepoCache {
 
                 if let Some(stale_value) = stale {
                     log::warn!(
-                        "cache refresh failed for key '{}': {}; serving stale value",
-                        storage_key,
-                        err
+                        "cache refresh failed for key '{storage_key}': {err}; serving stale value"
                     );
                     return Ok(stale_value);
                 }
 
-                log::warn!("cache refresh-failed key='{}': {}", storage_key, err);
+                log::warn!("cache refresh-failed key='{storage_key}': {err}");
                 Err(err)
             }
         }
@@ -226,13 +224,11 @@ impl RepoCache {
         match result {
             Ok(value) => self
                 .clone_typed::<T>(&value)
-                .ok_or_else(|| format!("Cached value type mismatch for key '{}'", storage_key)),
+                .ok_or_else(|| format!("Cached value type mismatch for key '{storage_key}'")),
             Err(err) => {
                 if let Some(stale_value) = stale {
                     log::warn!(
-                        "cache refresh failed for key '{}': {}; serving stale value",
-                        storage_key,
-                        err
+                        "cache refresh failed for key '{storage_key}': {err}; serving stale value"
                     );
                     Ok(stale_value)
                 } else {
@@ -251,7 +247,7 @@ impl RepoCache {
 
     fn build_storage_key(&self, namespace: &str, key: &str) -> String {
         let generation = self.generation.load(Ordering::SeqCst);
-        format!("{}:{}:{}", generation, namespace, key)
+        format!("{generation}:{namespace}:{key}")
     }
 }
 

--- a/crates/git/models/graph.rs
+++ b/crates/git/models/graph.rs
@@ -22,7 +22,6 @@ pub struct GraphLogEntry {
     pub parents: Vec<String>,
     pub author_name: String,
     pub author_email: String,
-    #[allow(dead_code)]
     pub author_time: i64,
     pub committer_name: String,
     pub committer_email: String,

--- a/crates/git/parsers/branch.rs
+++ b/crates/git/parsers/branch.rs
@@ -99,7 +99,7 @@ mod tests {
     fn skip_malformed_records() {
         // Record with too few parts
         let malformed = "main\u{001f}abc123";
-        let branches = parse_branch_records(&malformed, false).unwrap();
+        let branches = parse_branch_records(malformed, false).unwrap();
         assert!(branches.is_empty());
     }
 }

--- a/crates/git/parsers/branch.rs
+++ b/crates/git/parsers/branch.rs
@@ -76,3 +76,30 @@ pub fn parse_branch_records(output: &str, is_remote: bool) -> Result<Vec<BranchI
 
     Ok(branches)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Edge case tests ──────────────────────────────────────────────
+
+    #[test]
+    fn parse_empty_output() {
+        let branches = parse_branch_records("", false).unwrap();
+        assert!(branches.is_empty());
+    }
+
+    #[test]
+    fn parse_whitespace_only_output() {
+        let branches = parse_branch_records("  \n\t\n  ", false).unwrap();
+        assert!(branches.is_empty());
+    }
+
+    #[test]
+    fn skip_malformed_records() {
+        // Record with too few parts
+        let malformed = "main\u{001f}abc123";
+        let branches = parse_branch_records(&malformed, false).unwrap();
+        assert!(branches.is_empty());
+    }
+}

--- a/crates/git/parsers/commit.rs
+++ b/crates/git/parsers/commit.rs
@@ -141,3 +141,132 @@ pub fn parse_author_line(line: &str) -> Option<Author> {
         email: String::new(),
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── normalize_email tests ────────────────────────────────────────
+
+    #[test]
+    fn normalize_email_removes_brackets() {
+        assert_eq!(normalize_email("<alice@example.com>"), "alice@example.com");
+    }
+
+    #[test]
+    fn normalize_email_trims_whitespace() {
+        assert_eq!(
+            normalize_email("  alice@example.com  "),
+            "alice@example.com"
+        );
+    }
+
+    #[test]
+    fn normalize_email_handles_both() {
+        assert_eq!(
+            normalize_email("  <alice@example.com>  "),
+            "alice@example.com"
+        );
+    }
+
+    #[test]
+    fn normalize_email_already_clean() {
+        assert_eq!(normalize_email("alice@example.com"), "alice@example.com");
+    }
+
+    // ── extract_co_authors tests ─────────────────────────────────────
+
+    #[test]
+    fn extract_co_authors_standard_format() {
+        let message = "Feature\n\nCo-authored-by: Bob <bob@example.com>";
+        let co_authors = extract_co_authors(message);
+        assert_eq!(co_authors.len(), 1);
+        assert_eq!(co_authors[0].name, "Bob");
+        assert_eq!(co_authors[0].email, "bob@example.com");
+    }
+
+    #[test]
+    fn extract_co_authors_case_insensitive() {
+        let message = "Feature\n\nCo-Authored-By: Bob <bob@example.com>";
+        let co_authors = extract_co_authors(message);
+        assert_eq!(co_authors.len(), 1);
+    }
+
+    #[test]
+    fn extract_co_authors_multiple() {
+        let message = "Feature\n\nCo-authored-by: Alice <alice@example.com>\nCo-authored-by: Bob <bob@example.com>\nCo-authored-by: Charlie <charlie@example.com>";
+        let co_authors = extract_co_authors(message);
+        assert_eq!(co_authors.len(), 3);
+    }
+
+    #[test]
+    fn extract_co_authors_none() {
+        let message = "Just a regular commit message";
+        let co_authors = extract_co_authors(message);
+        assert!(co_authors.is_empty());
+    }
+
+    #[test]
+    fn extract_co_authors_name_only() {
+        let message = "Feature\n\nCo-authored-by: Bob";
+        let co_authors = extract_co_authors(message);
+        assert_eq!(co_authors.len(), 1);
+        assert_eq!(co_authors[0].name, "Bob");
+        assert_eq!(co_authors[0].email, "");
+    }
+
+    // ── parse_shortstat edge case ────────────────────────────────────
+
+    #[test]
+    fn parse_shortstat_empty() {
+        // Edge case: empty input should return zeros
+        let output = "";
+        let stats = parse_shortstat(output);
+        assert_eq!(stats.files_changed, 0);
+        assert_eq!(stats.insertions, 0);
+        assert_eq!(stats.deletions, 0);
+    }
+
+    // ── parse_author_line tests ──────────────────────────────────────
+
+    #[test]
+    fn parse_author_line_full() {
+        let line = "Co-authored-by: Alice Smith <alice@example.com>";
+        let author = parse_author_line(line).unwrap();
+        assert_eq!(author.name, "Alice Smith");
+        assert_eq!(author.email, "alice@example.com");
+    }
+
+    #[test]
+    fn parse_author_line_name_only() {
+        let line = "Co-authored-by: Alice";
+        let author = parse_author_line(line).unwrap();
+        assert_eq!(author.name, "Alice");
+        assert_eq!(author.email, "");
+    }
+
+    #[test]
+    fn parse_author_line_no_colon() {
+        let line = "Invalid line";
+        let author = parse_author_line(line);
+        assert!(author.is_none());
+    }
+
+    #[test]
+    fn parse_author_line_empty_after_colon() {
+        let line = "Co-authored-by:";
+        let author = parse_author_line(line);
+        // Returns Some with empty name if there's content after colon
+        assert!(author.is_none() || author.unwrap().name.is_empty());
+    }
+
+    // ── parse_commit_record edge case ────────────────────────────────
+
+    #[test]
+    fn parse_commit_record_invalid_too_few_parts() {
+        let record = "abc123\u{001f}Alice";
+        let result = parse_commit_record(record);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid commit record"));
+    }
+}

--- a/crates/git/parsers/commit.rs
+++ b/crates/git/parsers/commit.rs
@@ -114,10 +114,10 @@ pub fn extract_co_authors(message: &str) -> Vec<Author> {
 
     for line in message.lines() {
         let line = line.trim();
-        if line.starts_with("Co-authored-by:") || line.starts_with("Co-Authored-By:") {
-            if let Some(author) = parse_author_line(line) {
-                co_authors.push(author);
-            }
+        if (line.starts_with("Co-authored-by:") || line.starts_with("Co-Authored-By:"))
+            && let Some(author) = parse_author_line(line)
+        {
+            co_authors.push(author);
         }
     }
 
@@ -127,13 +127,13 @@ pub fn extract_co_authors(message: &str) -> Vec<Author> {
 pub fn parse_author_line(line: &str) -> Option<Author> {
     let line = line.split(':').nth(1)?.trim();
 
-    if let Some(email_start) = line.rfind('<') {
-        if let Some(email_end) = line.rfind('>') {
-            let name = line[..email_start].trim().to_string();
-            let email = line[email_start + 1..email_end].trim().to_string();
+    if let Some(email_start) = line.rfind('<')
+        && let Some(email_end) = line.rfind('>')
+    {
+        let name = line[..email_start].trim().to_string();
+        let email = line[email_start + 1..email_end].trim().to_string();
 
-            return Some(Author { name, email });
-        }
+        return Some(Author { name, email });
     }
 
     Some(Author {

--- a/crates/git/parsers/graph.rs
+++ b/crates/git/parsers/graph.rs
@@ -56,17 +56,16 @@ pub fn parse_search_query(input: &str) -> GraphSearchQuery {
             None => (false, token.as_str()),
         };
 
-        if let Some((key, value)) = token.split_once(':') {
-            if let Some(search_key) = parse_search_key(key) {
-                if !value.is_empty() {
-                    terms.push(GraphSearchTerm {
-                        key: Some(search_key),
-                        value: value.to_string(),
-                        negated,
-                    });
-                    continue;
-                }
-            }
+        if let Some((key, value)) = token.split_once(':')
+            && let Some(search_key) = parse_search_key(key)
+            && !value.is_empty()
+        {
+            terms.push(GraphSearchTerm {
+                key: Some(search_key),
+                value: value.to_string(),
+                negated,
+            });
+            continue;
         }
 
         if !token.is_empty() {

--- a/crates/git/parsers/history.rs
+++ b/crates/git/parsers/history.rs
@@ -14,3 +14,29 @@ pub fn parse_history_records(output: &str) -> Result<Vec<CommitInfo>, String> {
     }
     Ok(commits)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Edge case tests ──────────────────────────────────────────────
+
+    #[test]
+    fn parse_empty_history() {
+        let result = parse_history_records("").unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn parse_whitespace_only() {
+        let result = parse_history_records("  \n\t\n  ").unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn parse_malformed_record_skipped() {
+        // Malformed records should be skipped, not cause errors
+        let result = parse_history_records("malformed\u{001e}also_bad").unwrap();
+        assert!(result.is_empty());
+    }
+}

--- a/crates/git/parsers/origin.rs
+++ b/crates/git/parsers/origin.rs
@@ -55,7 +55,7 @@ pub fn parse_remote_url(
     ("unknown".into(), None, None, None, None)
 }
 
-pub fn detect_provider(host: &String) -> Option<String> {
+pub fn detect_provider(host: &str) -> Option<String> {
     if host.contains("github") {
         Some("github".into())
     } else if host.contains("gitlab") {
@@ -218,24 +218,18 @@ mod tests {
 
     #[test]
     fn detect_github_provider() {
+        assert_eq!(detect_provider("github.com"), Some("github".to_string()));
         assert_eq!(
-            detect_provider(&"github.com".to_string()),
-            Some("github".to_string())
-        );
-        assert_eq!(
-            detect_provider(&"api.github.com".to_string()),
+            detect_provider("api.github.com"),
             Some("github".to_string())
         );
     }
 
     #[test]
     fn detect_gitlab_provider() {
+        assert_eq!(detect_provider("gitlab.com"), Some("gitlab".to_string()));
         assert_eq!(
-            detect_provider(&"gitlab.com".to_string()),
-            Some("gitlab".to_string())
-        );
-        assert_eq!(
-            detect_provider(&"gitlab.company.com".to_string()),
+            detect_provider("gitlab.company.com"),
             Some("gitlab".to_string())
         );
     }
@@ -243,7 +237,7 @@ mod tests {
     #[test]
     fn detect_bitbucket_provider() {
         assert_eq!(
-            detect_provider(&"bitbucket.org".to_string()),
+            detect_provider("bitbucket.org"),
             Some("bitbucket".to_string())
         );
     }
@@ -251,11 +245,11 @@ mod tests {
     #[test]
     fn detect_unknown_provider() {
         assert_eq!(
-            detect_provider(&"git.example.com".to_string()),
+            detect_provider("git.example.com"),
             Some("unknown".to_string())
         );
         assert_eq!(
-            detect_provider(&"sourcehut.org".to_string()),
+            detect_provider("sourcehut.org"),
             Some("unknown".to_string())
         );
     }

--- a/crates/git/parsers/origin.rs
+++ b/crates/git/parsers/origin.rs
@@ -66,3 +66,197 @@ pub fn detect_provider(host: &String) -> Option<String> {
         Some("unknown".into())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── parse_remote_url SSH tests ───────────────────────────────────
+
+    #[test]
+    fn parse_ssh_github_url() {
+        let (protocol, host, owner, repo, provider) =
+            parse_remote_url("git@github.com:user/repo.git");
+
+        assert_eq!(protocol, "ssh");
+        assert_eq!(host, Some("github.com".to_string()));
+        assert_eq!(owner, Some("user".to_string()));
+        assert_eq!(repo, Some("repo".to_string()));
+        assert_eq!(provider, Some("github".to_string()));
+    }
+
+    #[test]
+    fn parse_ssh_gitlab_url() {
+        let (protocol, host, owner, repo, provider) =
+            parse_remote_url("git@gitlab.com:organization/project.git");
+
+        assert_eq!(protocol, "ssh");
+        assert_eq!(host, Some("gitlab.com".to_string()));
+        assert_eq!(owner, Some("organization".to_string()));
+        assert_eq!(repo, Some("project".to_string()));
+        assert_eq!(provider, Some("gitlab".to_string()));
+    }
+
+    #[test]
+    fn parse_ssh_bitbucket_url() {
+        let (protocol, host, owner, repo, provider) =
+            parse_remote_url("git@bitbucket.org:team/repo.git");
+
+        assert_eq!(protocol, "ssh");
+        assert_eq!(host, Some("bitbucket.org".to_string()));
+        assert_eq!(owner, Some("team".to_string()));
+        assert_eq!(repo, Some("repo".to_string()));
+        assert_eq!(provider, Some("bitbucket".to_string()));
+    }
+
+    #[test]
+    fn parse_ssh_without_git_extension() {
+        let (protocol, host, owner, repo, provider) = parse_remote_url("git@github.com:user/repo");
+
+        assert_eq!(protocol, "ssh");
+        assert_eq!(host, Some("github.com".to_string()));
+        assert_eq!(owner, Some("user".to_string()));
+        assert_eq!(repo, Some("repo".to_string()));
+        assert_eq!(provider, Some("github".to_string()));
+    }
+
+    #[test]
+    fn parse_ssh_self_hosted() {
+        let (protocol, host, owner, repo, provider) =
+            parse_remote_url("git@git.company.com:team/project.git");
+
+        assert_eq!(protocol, "ssh");
+        assert_eq!(host, Some("git.company.com".to_string()));
+        assert_eq!(owner, Some("team".to_string()));
+        assert_eq!(repo, Some("project".to_string()));
+        assert_eq!(provider, Some("unknown".to_string()));
+    }
+
+    // ── parse_remote_url HTTPS tests ─────────────────────────────────
+
+    #[test]
+    fn parse_https_github_url() {
+        let (protocol, host, owner, repo, provider) =
+            parse_remote_url("https://github.com/user/repo.git");
+
+        assert_eq!(protocol, "https");
+        assert_eq!(host, Some("github.com".to_string()));
+        assert_eq!(owner, Some("user".to_string()));
+        assert_eq!(repo, Some("repo".to_string()));
+        assert_eq!(provider, Some("github".to_string()));
+    }
+
+    #[test]
+    fn parse_http_url() {
+        let (protocol, host, owner, repo, provider) =
+            parse_remote_url("http://github.com/user/repo.git");
+
+        assert_eq!(protocol, "https"); // Note: both http and https return "https"
+        assert_eq!(host, Some("github.com".to_string()));
+        assert_eq!(owner, Some("user".to_string()));
+        assert_eq!(repo, Some("repo".to_string()));
+        assert_eq!(provider, Some("github".to_string()));
+    }
+
+    #[test]
+    fn parse_https_without_git_extension() {
+        let (protocol, host, owner, repo, provider) =
+            parse_remote_url("https://github.com/user/repo");
+
+        assert_eq!(protocol, "https");
+        assert_eq!(host, Some("github.com".to_string()));
+        assert_eq!(owner, Some("user".to_string()));
+        assert_eq!(repo, Some("repo".to_string()));
+        assert_eq!(provider, Some("github".to_string()));
+    }
+
+    #[test]
+    fn parse_https_self_hosted_gitlab() {
+        let (protocol, host, owner, repo, provider) =
+            parse_remote_url("https://gitlab.company.com/team/project.git");
+
+        assert_eq!(protocol, "https");
+        assert_eq!(host, Some("gitlab.company.com".to_string()));
+        assert_eq!(owner, Some("team".to_string()));
+        assert_eq!(repo, Some("project".to_string()));
+        assert_eq!(provider, Some("gitlab".to_string()));
+    }
+
+    // ── parse_remote_url edge cases ──────────────────────────────────
+
+    #[test]
+    fn parse_unknown_url_format() {
+        let (protocol, host, owner, repo, provider) = parse_remote_url("svn://example.com/repo");
+
+        assert_eq!(protocol, "unknown");
+        assert!(host.is_none());
+        assert!(owner.is_none());
+        assert!(repo.is_none());
+        assert!(provider.is_none());
+    }
+
+    #[test]
+    fn parse_empty_url() {
+        let (protocol, host, owner, repo, provider) = parse_remote_url("");
+
+        assert_eq!(protocol, "unknown");
+        assert!(host.is_none());
+        assert!(owner.is_none());
+        assert!(repo.is_none());
+        assert!(provider.is_none());
+    }
+
+    #[test]
+    fn parse_url_with_port() {
+        // This might not parse perfectly but shouldn't crash
+        let result = parse_remote_url("https://github.com:443/user/repo.git");
+        // Should at least not panic
+        assert!(!result.0.is_empty());
+    }
+
+    // ── detect_provider tests ────────────────────────────────────────
+
+    #[test]
+    fn detect_github_provider() {
+        assert_eq!(
+            detect_provider(&"github.com".to_string()),
+            Some("github".to_string())
+        );
+        assert_eq!(
+            detect_provider(&"api.github.com".to_string()),
+            Some("github".to_string())
+        );
+    }
+
+    #[test]
+    fn detect_gitlab_provider() {
+        assert_eq!(
+            detect_provider(&"gitlab.com".to_string()),
+            Some("gitlab".to_string())
+        );
+        assert_eq!(
+            detect_provider(&"gitlab.company.com".to_string()),
+            Some("gitlab".to_string())
+        );
+    }
+
+    #[test]
+    fn detect_bitbucket_provider() {
+        assert_eq!(
+            detect_provider(&"bitbucket.org".to_string()),
+            Some("bitbucket".to_string())
+        );
+    }
+
+    #[test]
+    fn detect_unknown_provider() {
+        assert_eq!(
+            detect_provider(&"git.example.com".to_string()),
+            Some("unknown".to_string())
+        );
+        assert_eq!(
+            detect_provider(&"sourcehut.org".to_string()),
+            Some("unknown".to_string())
+        );
+    }
+}

--- a/crates/git/parsers/stash.rs
+++ b/crates/git/parsers/stash.rs
@@ -64,14 +64,14 @@ pub fn parse_stash_stat(output: &str, reference: &str) -> Result<StashQuickStat,
             if let Some(n) = extract_leading_number(part) {
                 files_changed = n;
             }
-        } else if part.contains("insertion") {
-            if let Some(n) = extract_leading_number(part) {
-                insertions = n;
-            }
-        } else if part.contains("deletion") {
-            if let Some(n) = extract_leading_number(part) {
-                deletions = n;
-            }
+        } else if part.contains("insertion")
+            && let Some(n) = extract_leading_number(part)
+        {
+            insertions = n;
+        } else if part.contains("deletion")
+            && let Some(n) = extract_leading_number(part)
+        {
+            deletions = n;
         }
     }
 

--- a/crates/git/parsers/stash.rs
+++ b/crates/git/parsers/stash.rs
@@ -203,8 +203,7 @@ pub fn validate_stash_ref(reference: &str) -> Result<(), String> {
         }
     }
     Err(format!(
-        "Invalid stash reference '{}': expected format stash@{{N}}",
-        reference
+        "Invalid stash reference '{reference}': expected format stash@{{N}}"
     ))
 }
 
@@ -216,9 +215,9 @@ fn parse_stash_index(reference: &str) -> Result<usize, String> {
         let inner = &reference[7..reference.len() - 1];
         inner
             .parse::<usize>()
-            .map_err(|_| format!("invalid stash index in '{}'", reference))
+            .map_err(|_| format!("invalid stash index in '{reference}'"))
     } else {
-        Err(format!("invalid stash reference '{}'", reference))
+        Err(format!("invalid stash reference '{reference}'"))
     }
 }
 

--- a/crates/git/parsers/stash.rs
+++ b/crates/git/parsers/stash.rs
@@ -248,30 +248,7 @@ fn extract_leading_number(s: &str) -> Option<usize> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_parse_stash_list() {
-        let output = "stash@{0}\x1fOn main: WIP changes\nstash@{1}\x1f!!Gitru<feature> -> <main>\n";
-        let entries = parse_stash_list(output).unwrap();
-        assert_eq!(entries.len(), 2);
-
-        assert_eq!(entries[0].index, 0);
-        assert_eq!(entries[0].reference, "stash@{0}");
-        assert_eq!(entries[0].message, "On main: WIP changes");
-        assert_eq!(entries[0].branch, Some("main".to_string()));
-        assert!(!entries[0].is_gitru);
-
-        assert_eq!(entries[1].index, 1);
-        assert!(entries[1].is_gitru);
-    }
-
-    #[test]
-    fn test_parse_stash_stat() {
-        let output = " src/main.rs | 10 ++++----\n src/lib.rs  |  5 ++---\n 2 files changed, 7 insertions(+), 8 deletions(-)\n";
-        let stat = parse_stash_stat(output, "stash@{0}").unwrap();
-        assert_eq!(stat.files_changed, 2);
-        assert_eq!(stat.insertions, 7);
-        assert_eq!(stat.deletions, 8);
-    }
+    // ── Pure function tests (no git data needed) ─────────────────────
 
     #[test]
     fn test_parse_gitru_stash_message() {
@@ -288,6 +265,13 @@ mod tests {
         let result = parse_gitru_stash_message(msg).unwrap();
         assert_eq!(result.0, "old-branch");
         assert_eq!(result.1, "new-branch");
+    }
+
+    #[test]
+    fn test_parse_gitru_stash_message_invalid() {
+        assert!(parse_gitru_stash_message("Regular stash message").is_none());
+        assert!(parse_gitru_stash_message("!!Gitru<> -> <main>").is_none());
+        assert!(parse_gitru_stash_message("!!Gitru<feature> -> <>").is_none());
     }
 
     #[test]
@@ -308,29 +292,45 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_stash_file_status() {
-        // With -z, git outputs alternating NUL-separated fields: status\0path\0
-        let output = b"M\0file1.rs\0A\0file2.rs\0D\0file3.rs\0";
-        let files = parse_stash_file_status(output).unwrap();
-        assert_eq!(files.len(), 3);
-        assert_eq!(files[0].path, "file1.rs");
-        assert!(matches!(files[0].status[0], FileStatusKind::IndexModified));
-        assert_eq!(files[1].path, "file2.rs");
-        assert!(matches!(files[1].status[0], FileStatusKind::IndexNew));
-        assert_eq!(files[2].path, "file3.rs");
-        assert!(matches!(files[2].status[0], FileStatusKind::IndexDeleted));
+    fn test_parse_stash_index() {
+        assert_eq!(parse_stash_index("stash@{0}").unwrap(), 0);
+        assert_eq!(parse_stash_index("stash@{5}").unwrap(), 5);
+        assert_eq!(parse_stash_index("stash@{99}").unwrap(), 99);
+        assert!(parse_stash_index("invalid").is_err());
+        assert!(parse_stash_index("stash@{abc}").is_err());
     }
 
     #[test]
-    fn test_parse_stash_file_status_rename() {
-        // Rename: R100\0old_path\0new_path\0
-        let output = b"R100\0old_name.rs\0new_name.rs\0M\0other.rs\0";
-        let files = parse_stash_file_status(output).unwrap();
-        assert_eq!(files.len(), 2);
-        assert_eq!(files[0].path, "old_name.rs");
-        assert_eq!(files[0].new_path, Some("new_name.rs".to_string()));
-        assert!(matches!(files[0].status[0], FileStatusKind::IndexRenamed));
-        assert_eq!(files[1].path, "other.rs");
-        assert!(matches!(files[1].status[0], FileStatusKind::IndexModified));
+    fn test_parse_branch_from_message() {
+        assert_eq!(
+            parse_branch_from_message("On main: WIP changes"),
+            Some("main".to_string())
+        );
+        assert_eq!(
+            parse_branch_from_message("On feature/test: some work"),
+            Some("feature/test".to_string())
+        );
+        assert!(parse_branch_from_message("Random message").is_none());
+    }
+
+    #[test]
+    fn test_extract_leading_number() {
+        assert_eq!(extract_leading_number("3 files changed"), Some(3));
+        assert_eq!(extract_leading_number("  42 insertions"), Some(42));
+        assert_eq!(extract_leading_number("no numbers"), None);
+    }
+
+    // ── Edge case tests ──────────────────────────────────────────────
+
+    #[test]
+    fn parse_empty_stash_list() {
+        let entries = parse_stash_list("").unwrap();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn parse_empty_stash_file_status() {
+        let files = parse_stash_file_status(b"").unwrap();
+        assert!(files.is_empty());
     }
 }

--- a/crates/git/parsers/status.rs
+++ b/crates/git/parsers/status.rs
@@ -111,3 +111,85 @@ pub fn push_xy_status(status: &mut Vec<FileStatusKind>, x: u8, y: u8) {
         _ => {}
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Edge case tests ──────────────────────────────────────────────
+
+    #[test]
+    fn parse_empty_status() {
+        let result = parse_porcelain_v2(&[]).unwrap();
+        assert!(result.is_empty());
+    }
+
+    // ── push_xy_status tests ─────────────────────────────────────────
+    // These are pure function unit tests that don't need real git data
+
+    #[test]
+    fn push_xy_status_all_index_statuses() {
+        let test_cases = [
+            (b'A', FileStatusKind::IndexNew),
+            (b'M', FileStatusKind::IndexModified),
+            (b'D', FileStatusKind::IndexDeleted),
+            (b'R', FileStatusKind::IndexRenamed),
+            (b'T', FileStatusKind::IndexTypechange),
+        ];
+
+        for (x, expected) in test_cases {
+            let mut status = Vec::new();
+            push_xy_status(&mut status, x, b'.');
+            assert!(
+                status
+                    .iter()
+                    .any(|s| std::mem::discriminant(s) == std::mem::discriminant(&expected)),
+                "Expected {:?} for x={}",
+                expected,
+                x as char
+            );
+        }
+    }
+
+    #[test]
+    fn push_xy_status_all_worktree_statuses() {
+        let test_cases = [
+            (b'A', FileStatusKind::WorktreeNew),
+            (b'M', FileStatusKind::WorktreeModified),
+            (b'D', FileStatusKind::WorktreeDeleted),
+            (b'R', FileStatusKind::WorktreeRenamed),
+            (b'T', FileStatusKind::WorktreeTypechange),
+            (b'X', FileStatusKind::WorktreeUnreadable),
+        ];
+
+        for (y, expected) in test_cases {
+            let mut status = Vec::new();
+            push_xy_status(&mut status, b'.', y);
+            assert!(
+                status
+                    .iter()
+                    .any(|s| std::mem::discriminant(s) == std::mem::discriminant(&expected)),
+                "Expected {:?} for y={}",
+                expected,
+                y as char
+            );
+        }
+    }
+
+    #[test]
+    fn push_xy_status_both() {
+        let mut status = Vec::new();
+        push_xy_status(&mut status, b'M', b'M');
+        assert_eq!(status.len(), 2);
+    }
+
+    #[test]
+    fn push_xy_status_unknown_codes() {
+        let mut status = Vec::new();
+        push_xy_status(&mut status, b'.', b'.');
+        assert!(status.is_empty());
+
+        push_xy_status(&mut status, b'?', b'!');
+        assert!(status.is_empty());
+    }
+}

--- a/crates/git/runner.rs
+++ b/crates/git/runner.rs
@@ -40,7 +40,7 @@ impl GitCommandRunner {
     pub fn new(repo_path: &str) -> Result<Self, String> {
         let path = Path::new(repo_path);
         if !path.is_dir() {
-            return Err(format!("Invalid repository path: {}", repo_path));
+            return Err(format!("Invalid repository path: {repo_path}"));
         }
         Ok(Self {
             repo_path: path.to_path_buf(),

--- a/crates/git/runner.rs
+++ b/crates/git/runner.rs
@@ -130,8 +130,9 @@ async fn run_git_command_once(
 }
 
 fn command_lock_for_repo(repo_path: &Path) -> Result<std::sync::Arc<AsyncMutex<()>>, String> {
-    static REPO_LOCKS: OnceLock<StdMutex<std::collections::HashMap<String, std::sync::Arc<AsyncMutex<()>>>>> =
-        OnceLock::new();
+    static REPO_LOCKS: OnceLock<
+        StdMutex<std::collections::HashMap<String, std::sync::Arc<AsyncMutex<()>>>>,
+    > = OnceLock::new();
 
     let locks = REPO_LOCKS.get_or_init(|| StdMutex::new(std::collections::HashMap::new()));
     let mut guard = locks
@@ -219,5 +220,167 @@ fn finalize_output(
                 output.status.code()
             ))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── validate_relative_path tests ─────────────────────────────────
+
+    #[test]
+    fn validate_simple_filename() {
+        assert!(validate_relative_path("file.txt").is_ok());
+    }
+
+    #[test]
+    fn validate_nested_path() {
+        assert!(validate_relative_path("src/main.rs").is_ok());
+        assert!(validate_relative_path("deeply/nested/path/to/file.rs").is_ok());
+    }
+
+    #[test]
+    fn validate_path_with_dots_in_name() {
+        assert!(validate_relative_path("file.test.rs").is_ok());
+        assert!(validate_relative_path(".gitignore").is_ok());
+        assert!(validate_relative_path("src/.hidden").is_ok());
+    }
+
+    #[test]
+    fn reject_absolute_path_unix() {
+        let result = validate_relative_path("/etc/passwd");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Absolute"));
+    }
+
+    #[test]
+    fn reject_absolute_path_windows() {
+        // Windows-style paths should be rejected when running on Windows
+        // On non-Windows systems, this test is a no-op as the path looks relative
+        #[cfg(windows)]
+        {
+            let result = validate_relative_path("C:\\Windows\\System32");
+            assert!(result.is_err());
+        }
+        #[cfg(not(windows))]
+        {
+            // On Unix, Windows paths look like relative paths with special characters
+            // which may or may not be rejected depending on implementation
+            let _ = validate_relative_path("C:\\Windows\\System32");
+        }
+    }
+
+    #[test]
+    fn reject_parent_directory_traversal() {
+        let result = validate_relative_path("../secret");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("traversal"));
+    }
+
+    #[test]
+    fn reject_nested_parent_traversal() {
+        let result = validate_relative_path("src/../../outside");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("traversal"));
+    }
+
+    #[test]
+    fn reject_multiple_parent_dirs() {
+        let result = validate_relative_path("../../../etc/passwd");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn allow_current_dir_component() {
+        // ./ is allowed (current directory)
+        assert!(validate_relative_path("./file.txt").is_ok());
+        assert!(validate_relative_path("src/./file.txt").is_ok());
+    }
+
+    #[test]
+    fn validate_path_with_spaces() {
+        assert!(validate_relative_path("path with spaces/file.txt").is_ok());
+    }
+
+    #[test]
+    fn validate_path_with_unicode() {
+        assert!(validate_relative_path("日本語/ファイル.rs").is_ok());
+    }
+
+    // ── is_index_lock_error tests ────────────────────────────────────
+
+    #[test]
+    fn detect_index_lock_error() {
+        let err = "fatal: Unable to create '/path/.git/index.lock': File exists.";
+        assert!(is_index_lock_error(err));
+    }
+
+    #[test]
+    fn detect_index_lock_error_variant() {
+        let err = "Another process is locking index.lock File exists";
+        assert!(is_index_lock_error(err));
+    }
+
+    #[test]
+    fn not_index_lock_error() {
+        let err = "fatal: not a git repository";
+        assert!(!is_index_lock_error(err));
+    }
+
+    #[test]
+    fn not_index_lock_partial_match() {
+        // Must have both parts
+        let err = "index.lock";
+        assert!(!is_index_lock_error(err));
+
+        let err = "File exists";
+        assert!(!is_index_lock_error(err));
+    }
+
+    // ── GitRunOptions tests ──────────────────────────────────────────
+
+    #[test]
+    fn default_read_options() {
+        let opts = GitRunOptions::default_read();
+        assert_eq!(opts.timeout, Duration::from_secs(30));
+        assert!(opts.allow_failure_codes.is_empty());
+    }
+
+    #[test]
+    fn with_timeout() {
+        let opts = GitRunOptions::default_read().with_timeout(Duration::from_secs(60));
+        assert_eq!(opts.timeout, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn allow_exit_codes() {
+        let opts = GitRunOptions::default_read().allow_exit_codes(&[1, 2]);
+        assert_eq!(opts.allow_failure_codes, &[1, 2]);
+    }
+
+    // ── GitCommandRunner tests ───────────────────────────────────────
+
+    #[test]
+    fn runner_rejects_invalid_path() {
+        let result = GitCommandRunner::new("/nonexistent/path/to/repo");
+        assert!(result.is_err());
+        let err = result.err().unwrap();
+        assert!(err.contains("Invalid repository path"));
+    }
+
+    #[test]
+    fn runner_accepts_valid_temp_dir() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+
+        // Initialize git repo
+        std::process::Command::new("git")
+            .current_dir(temp_dir.path())
+            .args(["init"])
+            .output()
+            .expect("failed to init git");
+
+        let result = GitCommandRunner::new(temp_dir.path().to_str().unwrap());
+        assert!(result.is_ok());
     }
 }

--- a/crates/git/runner.rs
+++ b/crates/git/runner.rs
@@ -112,11 +112,11 @@ async fn run_git_command_once(
         .spawn()
         .map_err(|e| e.to_string())?;
 
-    if let Some(payload) = input {
-        if let Some(mut stdin) = child.stdin.take() {
-            stdin.write_all(payload).await.map_err(|e| e.to_string())?;
-            drop(stdin);
-        }
+    if let Some(payload) = input
+        && let Some(mut stdin) = child.stdin.take()
+    {
+        stdin.write_all(payload).await.map_err(|e| e.to_string())?;
+        drop(stdin);
     }
 
     match timeout(options.timeout, child.wait_with_output()).await {
@@ -176,10 +176,10 @@ pub fn throttle_command(repo_key: &str, min_interval: Duration) -> Result<(), St
 
     map.retain(|_, last| now.duration_since(*last) < Duration::from_secs(3600));
 
-    if let Some(last) = map.get(repo_key) {
-        if now.duration_since(*last) < min_interval {
-            return Err("Command throttled to protect performance".to_string());
-        }
+    if let Some(last) = map.get(repo_key)
+        && now.duration_since(*last) < min_interval
+    {
+        return Err("Command throttled to protect performance".to_string());
     }
 
     map.insert(repo_key.to_string(), now);

--- a/crates/git/runner.rs
+++ b/crates/git/runner.rs
@@ -248,6 +248,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn reject_absolute_path_unix() {
         let result = validate_relative_path("/etc/passwd");
         assert!(result.is_err());

--- a/crates/git/service/actions.rs
+++ b/crates/git/service/actions.rs
@@ -181,8 +181,7 @@ impl ActionService {
         match (restore_result, clean_result) {
             (Ok(_), _) | (Err(_), Ok(_)) => Ok(()),
             (Err(restore_err), Err(clean_err)) => Err(format!(
-                "Failed to discard changes for '{}': restore failed ({}) and clean failed ({})",
-                file, restore_err, clean_err
+                "Failed to discard changes for '{file}': restore failed ({restore_err}) and clean failed ({clean_err})"
             )),
         }
     }

--- a/crates/git/service/branch.rs
+++ b/crates/git/service/branch.rs
@@ -4,7 +4,7 @@ use crate::models::branch::{
     AheadBehindStatus, Branch, BranchInfo, BranchKind, UncommittedChangesStrategy,
 };
 use crate::models::stash::BranchStash;
-use crate::parsers::branch::{parse_branch_records, BRANCH_STANDARD_FORMAT};
+use crate::parsers::branch::{BRANCH_STANDARD_FORMAT, parse_branch_records};
 use crate::runner::GitRunOptions;
 use crate::service::query::QueryService;
 use crate::service::stash::StashService;

--- a/crates/git/service/branch.rs
+++ b/crates/git/service/branch.rs
@@ -192,8 +192,7 @@ impl BranchService {
                             let _ = self.stash().pop(None).await;
                         }
                         Err(format!(
-                            "Failed to switch to {} even after stashing: {}",
-                            branch, err
+                            "Failed to switch to {branch} even after stashing: {err}"
                         ))
                     }
                 }
@@ -202,14 +201,13 @@ impl BranchService {
             _ => match do_switch().await {
                 Ok(_) => {
                     self.ctx.cache.invalidate_all();
-                    Ok(format!("Switched to {}", branch))
+                    Ok(format!("Switched to {branch}"))
                 }
                 Err(err) => match strategy {
                     Some(UncommittedChangesStrategy::BringChanges) => Err(format!(
-                        "Cannot bring uncommitted changes to {}: conflicts detected",
-                        branch
+                        "Cannot bring uncommitted changes to {branch}: conflicts detected"
                     )),
-                    None => Err(format!("Cannot switch to {}: {}", branch, err)),
+                    None => Err(format!("Cannot switch to {branch}: {err}")),
                     _ => unreachable!(),
                 },
             },
@@ -250,8 +248,7 @@ impl BranchService {
                             let _ = self.stash().pop(None).await;
                         }
                         Err(format!(
-                            "Failed to create branch {} even after stashing: {}",
-                            branch, err
+                            "Failed to create branch {branch} even after stashing: {err}"
                         ))
                     }
                 }
@@ -266,14 +263,13 @@ impl BranchService {
             {
                 Ok(_) => {
                     self.ctx.cache.invalidate_all();
-                    Ok(format!("Created and switched to {}", branch))
+                    Ok(format!("Created and switched to {branch}"))
                 }
                 Err(err) => match strategy {
                     Some(UncommittedChangesStrategy::BringChanges) => Err(format!(
-                        "Cannot bring uncommitted changes to new branch {}: {}",
-                        branch, err
+                        "Cannot bring uncommitted changes to new branch {branch}: {err}"
                     )),
-                    None => Err(format!("Cannot create branch {}: {}", branch, err)),
+                    None => Err(format!("Cannot create branch {branch}: {err}")),
                     _ => unreachable!(),
                 },
             },

--- a/crates/git/service/commit.rs
+++ b/crates/git/service/commit.rs
@@ -159,7 +159,7 @@ impl CommitService {
         if !commit_meta.co_authors.is_empty() {
             msg.push('\n');
             for (name, email) in &commit_meta.co_authors {
-                msg.push_str(&format!("Co-authored-by: {} <{}>\n", name, email));
+                msg.push_str(&format!("Co-authored-by: {name} <{email}>\n"));
             }
         }
 

--- a/crates/git/service/graph.rs
+++ b/crates/git/service/graph.rs
@@ -876,7 +876,7 @@ fn normalize_refs(entries: &mut [GraphLogEntry], remote_names: &[String]) {
             }
 
             let is_remote = remote_names.iter().any(|remote| {
-                let prefix = format!("{}/", remote);
+                let prefix = format!("{remote}/");
                 reference.name.starts_with(&prefix)
             });
 

--- a/crates/git/service/graph.rs
+++ b/crates/git/service/graph.rs
@@ -285,10 +285,10 @@ pub fn history_graph(
                 .any(|r| matches!(r.kind, GraphRefKind::Stash));
             let result = graph_state.process_commit(&entry.id, &entry.parents, is_stash);
 
-            if let Some(ref query) = search_query {
-                if !matches_search(&entry, query, search_context.as_ref()) {
-                    continue;
-                }
+            if let Some(ref query) = search_query
+                && !matches_search(&entry, query, search_context.as_ref())
+            {
+                continue;
             }
 
             let stats = stats_map
@@ -704,10 +704,10 @@ fn extract_co_authors(body: &str) -> Vec<Author> {
 
     for line in body.lines() {
         let line = line.trim();
-        if line.starts_with("Co-authored-by:") || line.starts_with("Co-Authored-By:") {
-            if let Some(author) = parse_author_line(line) {
-                co_authors.push(author);
-            }
+        if (line.starts_with("Co-authored-by:") || line.starts_with("Co-Authored-By:"))
+            && let Some(author) = parse_author_line(line)
+        {
+            co_authors.push(author);
         }
     }
 
@@ -717,12 +717,12 @@ fn extract_co_authors(body: &str) -> Vec<Author> {
 fn parse_author_line(line: &str) -> Option<Author> {
     let line = line.split(':').nth(1)?.trim();
 
-    if let Some(email_start) = line.rfind('<') {
-        if let Some(email_end) = line.rfind('>') {
-            let name = line[..email_start].trim().to_string();
-            let email = line[email_start + 1..email_end].trim().to_string();
-            return Some(Author { name, email });
-        }
+    if let Some(email_start) = line.rfind('<')
+        && let Some(email_end) = line.rfind('>')
+    {
+        let name = line[..email_start].trim().to_string();
+        let email = line[email_start + 1..email_end].trim().to_string();
+        return Some(Author { name, email });
     }
 
     Some(Author {
@@ -761,10 +761,10 @@ fn matches_term(
 ) -> bool {
     let value = term.value.to_ascii_lowercase();
 
-    if value == "@me" {
-        if let Some(context) = context {
-            return matches_me(entry, context);
-        }
+    if value == "@me"
+        && let Some(context) = context
+    {
+        return matches_me(entry, context);
     }
 
     match term.key {

--- a/crates/git/service/stash.rs
+++ b/crates/git/service/stash.rs
@@ -153,7 +153,7 @@ impl StashService {
         let resolved_ref = self.resolve_reference(reference)?;
 
         if !self.stash_ref_exists(&resolved_ref).await {
-            return Err(format!("Stash '{}' does not exist", resolved_ref));
+            return Err(format!("Stash '{resolved_ref}' does not exist"));
         }
 
         let result = self
@@ -168,27 +168,25 @@ impl StashService {
         match result {
             Ok(_) => {
                 self.ctx.cache.invalidate_all();
-                Ok(format!("Popped {}", resolved_ref))
+                Ok(format!("Popped {resolved_ref}"))
             }
             Err(err) => {
                 // Some git versions can report non-zero exit even when the stash
                 // entry has already been removed. If the ref is gone, treat as success.
                 if !self.stash_ref_exists(&resolved_ref).await {
                     self.ctx.cache.invalidate_all();
-                    return Ok(format!("Popped {}", resolved_ref));
+                    return Ok(format!("Popped {resolved_ref}"));
                 }
 
                 if Self::is_untracked_conflict_error(&err) {
                     return Err(format!(
-                        "Unable to pop {} because untracked files would be overwritten. Resolve file conflicts and retry.",
-                        resolved_ref
+                        "Unable to pop {resolved_ref} because untracked files would be overwritten. Resolve file conflicts and retry."
                     ));
                 }
 
                 if Self::is_merge_conflict_error(&err) {
                     return Err(format!(
-                        "Stash {} was applied with conflicts and kept in stash list. Resolve conflicts, then drop it when ready.",
-                        resolved_ref
+                        "Stash {resolved_ref} was applied with conflicts and kept in stash list. Resolve conflicts, then drop it when ready."
                     ));
                 }
 
@@ -211,7 +209,7 @@ impl StashService {
             .await?;
 
         self.ctx.cache.invalidate_all();
-        Ok(format!("Applied {}", resolved_ref))
+        Ok(format!("Applied {resolved_ref}"))
     }
 
     /// Drop a single stash entry.
@@ -228,7 +226,7 @@ impl StashService {
             .await?;
 
         self.ctx.cache.invalidate_all();
-        Ok(format!("Dropped {}", reference))
+        Ok(format!("Dropped {reference}"))
     }
 
     /// Clear all stash entries.
@@ -262,8 +260,7 @@ impl StashService {
 
         self.ctx.cache.invalidate_all();
         Ok(format!(
-            "Created branch '{}' from {}",
-            branch_name, resolved_ref
+            "Created branch '{branch_name}' from {resolved_ref}"
         ))
     }
 
@@ -332,7 +329,7 @@ impl StashService {
             .await?;
 
         self.ctx.cache.invalidate_all();
-        Ok(format!("Restored '{}' from {}", file_path, reference))
+        Ok(format!("Restored '{file_path}' from {reference}"))
     }
 
     fn remove_path_if_exists(repo_path: &str, relative_path: &str) -> Result<(), String> {
@@ -344,11 +341,11 @@ impl StashService {
 
         if absolute_path.is_dir() {
             fs::remove_dir_all(&absolute_path).map_err(|error| {
-                format!("Failed to remove directory '{}': {}", relative_path, error)
+                format!("Failed to remove directory '{relative_path}': {error}")
             })?;
         } else {
             fs::remove_file(&absolute_path)
-                .map_err(|error| format!("Failed to remove file '{}': {}", relative_path, error))?;
+                .map_err(|error| format!("Failed to remove file '{relative_path}': {error}"))?;
         }
 
         Ok(())
@@ -367,7 +364,7 @@ impl StashService {
         is_new_branch: bool,
     ) -> Result<bool, String> {
         let suffix = if is_new_branch { " (new)" } else { "" };
-        let stash_msg = format!("!!Gitru<{}> -> <{}>{}", from_branch, to_branch, suffix);
+        let stash_msg = format!("!!Gitru<{from_branch}> -> <{to_branch}>{suffix}");
 
         let output = self
             .ctx
@@ -448,7 +445,7 @@ impl StashService {
         let stash = self
             .find_gitru_stash_for_branch(branch)
             .await?
-            .ok_or_else(|| format!("No !!Gitru stash found for branch '{}'", branch))?;
+            .ok_or_else(|| format!("No !!Gitru stash found for branch '{branch}'"))?;
 
         self.pop(Some(&stash.reference)).await
     }

--- a/crates/git/tests/actions_service.rs
+++ b/crates/git/tests/actions_service.rs
@@ -1,0 +1,416 @@
+//! Integration tests for ActionService.
+//!
+//! Tests git_add, git_remove, git_discard, get_status, and related actions.
+
+mod common;
+
+use common::{run_async, TestRepo};
+use git::context::RepoContext;
+use git::service::actions::ActionService;
+use serial_test::serial;
+use std::sync::Arc;
+
+fn setup_action_service(repo: &TestRepo) -> ActionService {
+    let ctx = Arc::new(RepoContext::new(repo.path_str()).expect("failed to create repo context"));
+    ActionService::new(ctx)
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// GIT ADD TESTS
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[serial]
+fn git_add_single_file() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        repo.create_file("new_file.txt", "content");
+
+        let service = setup_action_service(&repo);
+        let result = service.git_add("new_file.txt").await;
+
+        assert!(result.is_ok());
+
+        // File should now be staged
+        assert!(repo.is_staged("new_file.txt"));
+    });
+}
+
+#[test]
+#[serial]
+fn git_add_all() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        repo.create_file("a.txt", "a");
+        repo.create_file("b.txt", "b");
+        repo.create_file("subdir/c.txt", "c");
+
+        let service = setup_action_service(&repo);
+        let result = service.git_add(".").await;
+
+        assert!(result.is_ok());
+    });
+}
+
+#[test]
+#[serial]
+fn git_add_modified_file() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Original", "Initial commit");
+
+        // Modify the tracked file
+        repo.create_file("README.md", "# Modified");
+
+        let service = setup_action_service(&repo);
+        let result = service.git_add("README.md").await;
+
+        assert!(result.is_ok());
+        assert!(repo.is_staged("README.md"));
+    });
+}
+
+#[test]
+#[serial]
+fn git_add_nonexistent_file() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+
+        let service = setup_action_service(&repo);
+        let result = service.git_add("nonexistent.txt").await;
+
+        // git add on nonexistent files fails
+        assert!(result.is_err());
+    });
+}
+
+#[test]
+#[serial]
+fn git_add_directory() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        repo.create_file("src/a.txt", "a");
+        repo.create_file("src/b.txt", "b");
+        repo.create_file("src/nested/c.txt", "c");
+
+        let service = setup_action_service(&repo);
+        let result = service.git_add("src").await;
+
+        assert!(result.is_ok());
+    });
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// GIT REMOVE TESTS (Unstage)
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[serial]
+fn git_remove_unstages_file() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        repo.create_file("staged.txt", "content");
+        repo.add("staged.txt");
+
+        assert!(repo.is_staged("staged.txt"));
+
+        let service = setup_action_service(&repo);
+        let result = service.git_remove("staged.txt").await;
+
+        assert!(result.is_ok());
+        assert!(!repo.is_staged("staged.txt"));
+    });
+}
+
+#[test]
+#[serial]
+fn git_remove_not_staged() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        repo.create_file("untracked.txt", "content");
+
+        let service = setup_action_service(&repo);
+        let result = service.git_remove("untracked.txt").await;
+
+        // git restore --staged on an untracked file fails
+        // This is expected behavior
+        assert!(result.is_err());
+    });
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// GIT DISCARD TESTS
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[serial]
+fn git_discard_modified_file() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Original", "Initial commit");
+        repo.create_file("README.md", "# Modified");
+
+        assert!(repo.has_changes());
+
+        let service = setup_action_service(&repo);
+        let result = service.git_discard("README.md", None).await;
+
+        assert!(result.is_ok());
+
+        // File should be restored to original
+        let content = std::fs::read_to_string(repo.path().join("README.md")).unwrap();
+        assert_eq!(content, "# Original");
+    });
+}
+
+#[test]
+#[serial]
+fn git_discard_untracked_file() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial");
+        repo.create_file("untracked.txt", "content");
+
+        let service = setup_action_service(&repo);
+        let result = service.git_discard("untracked.txt", None).await;
+
+        // For untracked files, discard removes the file
+        // Just verify it doesn't panic
+        let _ = result;
+    });
+}
+
+#[test]
+#[serial]
+fn git_discard_staged_changes() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Original", "Initial");
+        repo.create_file("README.md", "# Modified");
+        repo.add("README.md");
+
+        let service = setup_action_service(&repo);
+        let result = service.git_discard("README.md", None).await;
+
+        assert!(result.is_ok());
+
+        let content = std::fs::read_to_string(repo.path().join("README.md")).unwrap();
+        assert_eq!(content, "# Original");
+    });
+}
+
+#[test]
+#[serial]
+fn git_discard_all() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("a.txt", "a", "Initial");
+        repo.commit_file("b.txt", "b", "Add b");
+
+        repo.create_file("a.txt", "modified-a");
+        repo.create_file("b.txt", "modified-b");
+
+        let service = setup_action_service(&repo);
+        let result = service.git_discard(".", Some(true)).await;
+
+        assert!(result.is_ok());
+        assert!(!repo.has_changes());
+    });
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// GET STATUS TESTS
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[serial]
+fn get_status_clean() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+
+        let service = setup_action_service(&repo);
+        let status = service.get_status().await.unwrap();
+
+        assert!(status.files.is_empty());
+    });
+}
+
+#[test]
+#[serial]
+fn get_status_untracked() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        repo.create_file("untracked.txt", "content");
+
+        let service = setup_action_service(&repo);
+        let status = service.get_status().await.unwrap();
+
+        assert!(!status.files.is_empty());
+        assert!(status.files.iter().any(|f| f.path == "untracked.txt"));
+    });
+}
+
+#[test]
+#[serial]
+fn get_status_staged_new_file() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        repo.create_file("new.txt", "content");
+        repo.add("new.txt");
+
+        let service = setup_action_service(&repo);
+        let status = service.get_status().await.unwrap();
+
+        assert!(!status.files.is_empty());
+        assert!(status.files.iter().any(|f| f.path == "new.txt"));
+    });
+}
+
+#[test]
+#[serial]
+fn get_status_modified() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Original", "Initial commit");
+        repo.create_file("README.md", "# Modified");
+
+        let service = setup_action_service(&repo);
+        let status = service.get_status().await.unwrap();
+
+        // Modified file should appear
+        assert!(!status.files.is_empty());
+    });
+}
+
+#[test]
+#[serial]
+fn get_status_deleted() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("to_delete.txt", "content", "Add file");
+
+        // Delete the file
+        std::fs::remove_file(repo.path().join("to_delete.txt")).unwrap();
+
+        let service = setup_action_service(&repo);
+        let status = service.get_status().await.unwrap();
+
+        // Deleted file should appear
+        assert!(!status.files.is_empty());
+    });
+}
+
+#[test]
+#[serial]
+fn get_status_renamed() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("old_name.txt", "content", "Add file");
+
+        // Use git mv to rename
+        repo.git(&["mv", "old_name.txt", "new_name.txt"]);
+
+        let service = setup_action_service(&repo);
+        let status = service.get_status().await.unwrap();
+
+        // Renamed file should appear
+        assert!(!status.files.is_empty());
+    });
+}
+
+#[test]
+#[serial]
+fn get_status_mixed() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("tracked.txt", "original", "Initial");
+
+        // Staged new file
+        repo.create_file("new.txt", "new");
+        repo.add("new.txt");
+
+        // Unstaged modified
+        repo.create_file("tracked.txt", "modified");
+
+        // Untracked
+        repo.create_file("untracked.txt", "untracked");
+
+        let service = setup_action_service(&repo);
+        let status = service.get_status().await.unwrap();
+
+        // Should have multiple files
+        assert!(status.files.len() >= 2);
+    });
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// EDGE CASES
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[serial]
+fn git_add_file_with_spaces() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        repo.create_file("file with spaces.txt", "content");
+
+        let service = setup_action_service(&repo);
+        let result = service.git_add("file with spaces.txt").await;
+
+        assert!(result.is_ok());
+    });
+}
+
+#[test]
+#[serial]
+fn git_add_file_with_unicode() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        repo.create_file("文件.txt", "内容");
+
+        let service = setup_action_service(&repo);
+        let result = service.git_add("文件.txt").await;
+
+        assert!(result.is_ok());
+    });
+}
+
+#[test]
+#[serial]
+fn git_version() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+
+        let service = setup_action_service(&repo);
+        let version = service.git_version().await.unwrap();
+
+        assert!(version.contains("git version"));
+    });
+}
+
+#[test]
+#[serial]
+fn git_fetch_no_remote() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+
+        let service = setup_action_service(&repo);
+        let result = service.git_fetch().await;
+
+        // Should succeed even without remote (no-op)
+        assert!(result.is_ok());
+    });
+}

--- a/crates/git/tests/actions_service.rs
+++ b/crates/git/tests/actions_service.rs
@@ -4,7 +4,7 @@
 
 mod common;
 
-use common::{run_async, TestRepo};
+use common::{TestRepo, run_async};
 use git::context::RepoContext;
 use git::service::actions::ActionService;
 use serial_test::serial;

--- a/crates/git/tests/branch_service.rs
+++ b/crates/git/tests/branch_service.rs
@@ -155,8 +155,7 @@ fn create_branch_already_exists() {
         // Git error message should mention the branch already exists
         assert!(
             err.contains("exists") || err.contains("already") || err.contains("fatal"),
-            "Expected error about existing branch, got: {}",
-            err
+            "Expected error about existing branch, got: {err}"
         );
     });
 }

--- a/crates/git/tests/branch_service.rs
+++ b/crates/git/tests/branch_service.rs
@@ -1,0 +1,486 @@
+//! Integration tests for BranchService.
+//!
+//! Tests branch creation, switching, and edge cases with uncommitted changes.
+
+mod common;
+
+use common::{run_async, TestRepo};
+use git::context::RepoContext;
+use git::models::branch::{BranchKind, UncommittedChangesStrategy};
+use git::service::branch::BranchService;
+use serial_test::serial;
+use std::sync::Arc;
+
+fn setup_branch_service(repo: &TestRepo) -> BranchService {
+    let ctx = Arc::new(RepoContext::new(repo.path_str()).expect("failed to create repo context"));
+    BranchService::new(ctx)
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// GET CURRENT BRANCH TESTS
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[serial]
+fn get_current_branch_on_main() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+
+        let service = setup_branch_service(&repo);
+        let branch = service.get_current_branch().await.unwrap();
+
+        // Default branch is either main or master depending on git config
+        assert!(branch.name == "main" || branch.name == "master");
+    });
+}
+
+#[test]
+#[serial]
+fn get_current_branch_after_switch() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        repo.create_branch("feature/test");
+
+        let service = setup_branch_service(&repo);
+        let branch = service.get_current_branch().await.unwrap();
+
+        assert_eq!(branch.name, "feature/test");
+    });
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// LIST BRANCHES TESTS
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[serial]
+fn list_branches_single_branch() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+
+        let service = setup_branch_service(&repo);
+        let branches = service.list_branches(BranchKind::Local).await.unwrap();
+
+        assert_eq!(branches.len(), 1);
+    });
+}
+
+#[test]
+#[serial]
+fn list_branches_multiple_branches() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        repo.create_branch("feature/one");
+        repo.git(&["switch", "-c", "feature/two"]);
+        repo.git(&["switch", "-c", "bugfix/issue-123"]);
+
+        let service = setup_branch_service(&repo);
+        let branches = service.list_branches(BranchKind::Local).await.unwrap();
+
+        // Should have main + 3 feature branches
+        assert!(branches.len() >= 4);
+
+        let branch_names: Vec<&str> = branches.iter().map(|b| b.name.as_str()).collect();
+        assert!(branch_names.contains(&"feature/one"));
+        assert!(branch_names.contains(&"feature/two"));
+        assert!(branch_names.contains(&"bugfix/issue-123"));
+    });
+}
+
+#[test]
+#[serial]
+fn list_branches_marks_head_correctly() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        repo.create_branch("feature/current");
+
+        let service = setup_branch_service(&repo);
+        let branches = service.list_branches(BranchKind::Local).await.unwrap();
+
+        // At least one branch should be marked as HEAD (the current branch)
+        let head_branches: Vec<_> = branches.iter().filter(|b| b.is_head).collect();
+        assert!(!head_branches.is_empty(), "Expected at least one HEAD branch");
+
+        // The current branch should be feature/current since we just created and switched to it
+        let current = service.get_current_branch().await.unwrap();
+        assert_eq!(current.name, "feature/current");
+    });
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// CREATE BRANCH TESTS
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[serial]
+fn create_branch_simple() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+
+        let service = setup_branch_service(&repo);
+        let result = service.create("feature/new-branch", None).await;
+
+        assert!(result.is_ok());
+        assert!(result.unwrap().contains("feature/new-branch"));
+
+        // Verify we're now on the new branch
+        let current = service.get_current_branch().await.unwrap();
+        assert_eq!(current.name, "feature/new-branch");
+    });
+}
+
+#[test]
+#[serial]
+fn create_branch_already_exists() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        repo.create_branch("existing-branch");
+        repo.switch_branch("main");
+
+        let service = setup_branch_service(&repo);
+        let result = service.create("existing-branch", None).await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        // Git error message should mention the branch already exists
+        assert!(
+            err.contains("exists") || err.contains("already") || err.contains("fatal"),
+            "Expected error about existing branch, got: {}",
+            err
+        );
+    });
+}
+
+#[test]
+#[serial]
+fn create_branch_with_slash_in_name() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+
+        let service = setup_branch_service(&repo);
+        let result = service.create("feature/deeply/nested/branch", None).await;
+
+        assert!(result.is_ok());
+
+        let current = service.get_current_branch().await.unwrap();
+        assert_eq!(current.name, "feature/deeply/nested/branch");
+    });
+}
+
+#[test]
+#[serial]
+fn create_branch_with_uncommitted_changes_bring_changes() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        repo.create_file("uncommitted.txt", "uncommitted content");
+
+        assert!(repo.has_changes());
+
+        let service = setup_branch_service(&repo);
+        let result = service
+            .create(
+                "feature/with-changes",
+                Some(UncommittedChangesStrategy::BringChanges),
+            )
+            .await;
+
+        // Should succeed and bring changes along
+        assert!(result.is_ok());
+
+        // Should still have uncommitted changes
+        assert!(repo.has_changes());
+
+        let current = service.get_current_branch().await.unwrap();
+        assert_eq!(current.name, "feature/with-changes");
+    });
+}
+
+#[test]
+#[serial]
+fn create_branch_with_uncommitted_changes_stash() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        repo.create_file("uncommitted.txt", "uncommitted content");
+
+        assert!(repo.has_changes());
+
+        let service = setup_branch_service(&repo);
+        let result = service
+            .create(
+                "feature/stashed",
+                Some(UncommittedChangesStrategy::StashOnCurrentBranch),
+            )
+            .await;
+
+        assert!(result.is_ok());
+
+        // Changes should be stashed (working tree clean)
+        assert!(!repo.has_changes());
+
+        // Should have a stash
+        let stash_list = repo.stash_list();
+        assert!(!stash_list.is_empty());
+    });
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// SWITCH BRANCH TESTS
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[serial]
+fn switch_branch_simple() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        repo.create_branch("feature/target");
+        repo.switch_branch("main");
+
+        let service = setup_branch_service(&repo);
+        let result = service.switch("feature/target", None).await;
+
+        assert!(result.is_ok());
+
+        let current = service.get_current_branch().await.unwrap();
+        assert_eq!(current.name, "feature/target");
+    });
+}
+
+#[test]
+#[serial]
+fn switch_branch_nonexistent() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+
+        let service = setup_branch_service(&repo);
+        let result = service.switch("nonexistent-branch", None).await;
+
+        assert!(result.is_err());
+    });
+}
+
+#[test]
+#[serial]
+fn switch_branch_with_uncommitted_changes_no_conflict() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        repo.create_branch("feature/target");
+        repo.switch_branch("main");
+
+        // Create a new file (not conflicting)
+        repo.create_file("new-file.txt", "content");
+
+        let service = setup_branch_service(&repo);
+        let result = service
+            .switch(
+                "feature/target",
+                Some(UncommittedChangesStrategy::BringChanges),
+            )
+            .await;
+
+        // Should succeed since the new file doesn't conflict
+        assert!(result.is_ok());
+    });
+}
+
+#[test]
+#[serial]
+fn switch_branch_with_uncommitted_changes_stash_strategy() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        repo.create_branch("feature/target");
+        repo.switch_branch("main");
+
+        // Create uncommitted changes
+        repo.create_file("changes.txt", "some changes");
+
+        let service = setup_branch_service(&repo);
+        let result = service
+            .switch(
+                "feature/target",
+                Some(UncommittedChangesStrategy::StashOnCurrentBranch),
+            )
+            .await;
+
+        assert!(result.is_ok());
+
+        // Working tree should be clean
+        assert!(!repo.has_changes());
+
+        // Should be on target branch
+        let current = service.get_current_branch().await.unwrap();
+        assert_eq!(current.name, "feature/target");
+    });
+}
+
+#[test]
+#[serial]
+fn switch_branch_with_conflicting_changes() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("shared.txt", "original content", "Initial commit");
+
+        // Create target branch with different content
+        repo.create_branch("feature/target");
+        std::fs::write(repo.path().join("shared.txt"), "target content").unwrap();
+        repo.add_all();
+        repo.commit("Change on target");
+
+        // Go back to main and modify the same file
+        repo.switch_branch("main");
+        std::fs::write(repo.path().join("shared.txt"), "main content").unwrap();
+
+        let service = setup_branch_service(&repo);
+
+        // Try to switch with BringChanges - should fail due to conflict
+        let result = service
+            .switch(
+                "feature/target",
+                Some(UncommittedChangesStrategy::BringChanges),
+            )
+            .await;
+
+        // Should fail because of conflicting changes
+        assert!(result.is_err());
+    });
+}
+
+#[test]
+#[serial]
+fn switch_branch_stash_rollback_on_failure() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+
+        // Create uncommitted changes
+        repo.create_file("changes.txt", "some changes");
+
+        let service = setup_branch_service(&repo);
+
+        // Try to switch to a non-existent branch with stash strategy
+        let result = service
+            .switch(
+                "nonexistent-branch",
+                Some(UncommittedChangesStrategy::StashOnCurrentBranch),
+            )
+            .await;
+
+        // Should fail
+        assert!(result.is_err());
+
+        // The stash should be rolled back (popped), so changes should still be present
+        // This tests the rollback logic in the switch method
+        assert!(repo.has_changes());
+    });
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// BRANCH INFO TESTS
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[serial]
+fn get_branch_info() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+
+        let service = setup_branch_service(&repo);
+        let info = service.get_branch_info("main").await.unwrap();
+
+        assert_eq!(info.name, "main");
+        assert!(!info.commit.id.is_empty());
+        assert!(!info.commit.summary.is_empty());
+    });
+}
+
+#[test]
+#[serial]
+fn get_branch_info_nonexistent() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+
+        let service = setup_branch_service(&repo);
+        let result = service.get_branch_info("nonexistent").await;
+
+        assert!(result.is_err());
+    });
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// HAS UNCOMMITTED CHANGES TESTS
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[serial]
+fn has_uncommitted_changes_false_when_clean() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+
+        let service = setup_branch_service(&repo);
+        let has_changes = service.has_uncommitted_changes().await.unwrap();
+
+        assert!(!has_changes);
+    });
+}
+
+#[test]
+#[serial]
+fn has_uncommitted_changes_true_with_modified() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        std::fs::write(repo.path().join("README.md"), "modified").unwrap();
+
+        let service = setup_branch_service(&repo);
+        let has_changes = service.has_uncommitted_changes().await.unwrap();
+
+        assert!(has_changes);
+    });
+}
+
+#[test]
+#[serial]
+fn has_uncommitted_changes_true_with_untracked() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        repo.create_file("untracked.txt", "content");
+
+        let service = setup_branch_service(&repo);
+        let has_changes = service.has_uncommitted_changes().await.unwrap();
+
+        assert!(has_changes);
+    });
+}
+
+#[test]
+#[serial]
+fn has_uncommitted_changes_true_with_staged() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        repo.create_file("new.txt", "content");
+        repo.add("new.txt");
+
+        let service = setup_branch_service(&repo);
+        let has_changes = service.has_uncommitted_changes().await.unwrap();
+
+        assert!(has_changes);
+    });
+}

--- a/crates/git/tests/branch_service.rs
+++ b/crates/git/tests/branch_service.rs
@@ -4,7 +4,7 @@
 
 mod common;
 
-use common::{run_async, TestRepo};
+use common::{TestRepo, run_async};
 use git::context::RepoContext;
 use git::models::branch::{BranchKind, UncommittedChangesStrategy};
 use git::service::branch::BranchService;
@@ -104,7 +104,10 @@ fn list_branches_marks_head_correctly() {
 
         // At least one branch should be marked as HEAD (the current branch)
         let head_branches: Vec<_> = branches.iter().filter(|b| b.is_head).collect();
-        assert!(!head_branches.is_empty(), "Expected at least one HEAD branch");
+        assert!(
+            !head_branches.is_empty(),
+            "Expected at least one HEAD branch"
+        );
 
         // The current branch should be feature/current since we just created and switched to it
         let current = service.get_current_branch().await.unwrap();

--- a/crates/git/tests/commit_service.rs
+++ b/crates/git/tests/commit_service.rs
@@ -1,0 +1,382 @@
+//! Integration tests for CommitService.
+//!
+//! Tests commit creation, retrieval, history, and co-author handling.
+
+mod common;
+
+use common::{run_async, TestRepo};
+use git::context::RepoContext;
+use git::models::commit::CommitMessage;
+use git::service::commit::CommitService;
+use serial_test::serial;
+use std::sync::Arc;
+
+fn setup_commit_service(repo: &TestRepo) -> CommitService {
+    let ctx = Arc::new(RepoContext::new(repo.path_str()).expect("failed to create repo context"));
+    CommitService::new(ctx)
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// LAST COMMIT TESTS
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[serial]
+fn last_commit_exists() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit message");
+
+        let service = setup_commit_service(&repo);
+        let commit = service.last_commit().await.unwrap();
+
+        assert_eq!(commit.summary, "Initial commit message");
+        assert!(!commit.id.is_empty());
+    });
+}
+
+#[test]
+#[serial]
+fn last_commit_empty_repo() {
+    run_async(async {
+        let repo = TestRepo::new();
+        // No commits made
+
+        let service = setup_commit_service(&repo);
+        let result = service.last_commit().await;
+
+        // Should fail - no commits
+        assert!(result.is_err());
+    });
+}
+
+#[test]
+#[serial]
+fn last_commit_after_multiple() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("file1.txt", "content1", "First commit");
+        repo.commit_file("file2.txt", "content2", "Second commit");
+        repo.commit_file("file3.txt", "content3", "Third commit");
+
+        let service = setup_commit_service(&repo);
+        let commit = service.last_commit().await.unwrap();
+
+        assert_eq!(commit.summary, "Third commit");
+    });
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// CREATE COMMIT TESTS
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[serial]
+fn create_commit_simple() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial");
+
+        // Stage changes
+        repo.create_file("new_file.txt", "content");
+        repo.add("new_file.txt");
+
+        let service = setup_commit_service(&repo);
+        let msg = CommitMessage {
+            title: "New feature commit".to_string(),
+            description: None,
+            co_authors: vec![],
+        };
+        let result = service.create_commit(&msg, false).await;
+
+        assert!(result.is_ok());
+
+        // Verify commit was created
+        let last = service.last_commit().await.unwrap();
+        assert_eq!(last.summary, "New feature commit");
+    });
+}
+
+#[test]
+#[serial]
+fn create_commit_with_co_author() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial");
+
+        repo.create_file("collab.txt", "collaboration");
+        repo.add("collab.txt");
+
+        let service = setup_commit_service(&repo);
+        let msg = CommitMessage {
+            title: "Pair programming".to_string(),
+            description: None,
+            co_authors: vec![("Alice".to_string(), "alice@example.com".to_string())],
+        };
+        let result = service.create_commit(&msg, false).await;
+
+        assert!(result.is_ok());
+
+        // Verify the commit was created with co-author
+        let last = service.last_commit().await.unwrap();
+        assert!(last.body.contains("Co-authored-by:") || last.summary.contains("Pair"));
+    });
+}
+
+#[test]
+#[serial]
+fn create_commit_with_multiple_co_authors() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial");
+
+        repo.create_file("team.txt", "team work");
+        repo.add("team.txt");
+
+        let service = setup_commit_service(&repo);
+        let msg = CommitMessage {
+            title: "Team effort".to_string(),
+            description: None,
+            co_authors: vec![
+                ("Alice".to_string(), "alice@example.com".to_string()),
+                ("Bob".to_string(), "bob@example.com".to_string()),
+            ],
+        };
+        let result = service.create_commit(&msg, false).await;
+
+        assert!(result.is_ok());
+    });
+}
+
+#[test]
+#[serial]
+fn create_commit_nothing_staged() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial");
+
+        // No changes staged
+        let service = setup_commit_service(&repo);
+        let msg = CommitMessage {
+            title: "Empty commit attempt".to_string(),
+            description: None,
+            co_authors: vec![],
+        };
+        let result = service.create_commit(&msg, false).await;
+
+        // Should fail - nothing to commit
+        assert!(result.is_err());
+    });
+}
+
+#[test]
+#[serial]
+fn create_commit_allow_empty() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial");
+
+        let service = setup_commit_service(&repo);
+        let msg = CommitMessage {
+            title: "Allow empty commit".to_string(),
+            description: None,
+            co_authors: vec![],
+        };
+        let result = service.create_commit(&msg, true).await;
+
+        // Should succeed with allow_empty=true
+        assert!(result.is_ok());
+    });
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// GET COMMIT BY ID TESTS
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[serial]
+fn get_commit_by_id() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Target commit");
+
+        let service = setup_commit_service(&repo);
+
+        // Get the commit hash
+        let last = service.last_commit().await.unwrap();
+        let hash = last.id.clone();
+
+        // Fetch by ID
+        let commit = service.commit_by_id(&hash).await.unwrap();
+
+        assert_eq!(commit.summary, "Target commit");
+    });
+}
+
+#[test]
+#[serial]
+fn get_commit_by_short_hash() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Short hash commit");
+
+        let service = setup_commit_service(&repo);
+
+        let last = service.last_commit().await.unwrap();
+        let short_hash = &last.id[..7];
+
+        let commit = service.commit_by_id(short_hash).await.unwrap();
+
+        assert_eq!(commit.summary, "Short hash commit");
+    });
+}
+
+#[test]
+#[serial]
+fn get_commit_by_invalid_id() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial");
+
+        let service = setup_commit_service(&repo);
+        let result = service.commit_by_id("0000000000000000000000000000000000000000").await;
+
+        // Should fail - invalid commit reference
+        assert!(result.is_err());
+    });
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// EDGE CASES
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[serial]
+fn create_commit_multiline_message() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial");
+
+        repo.create_file("feature.txt", "content");
+        repo.add("feature.txt");
+
+        let service = setup_commit_service(&repo);
+        let msg = CommitMessage {
+            title: "Subject line".to_string(),
+            description: Some("This is the body of the commit.\nIt has multiple lines.".to_string()),
+            co_authors: vec![],
+        };
+        let result = service.create_commit(&msg, false).await;
+
+        assert!(result.is_ok());
+
+        let last = service.last_commit().await.unwrap();
+        assert_eq!(last.summary, "Subject line");
+        assert!(last.body.contains("multiple lines"));
+    });
+}
+
+#[test]
+#[serial]
+fn create_commit_special_characters_in_message() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial");
+
+        repo.create_file("special.txt", "content");
+        repo.add("special.txt");
+
+        let service = setup_commit_service(&repo);
+        let msg = CommitMessage {
+            title: "fix: handle 'quotes' and \"double quotes\" & special chars".to_string(),
+            description: None,
+            co_authors: vec![],
+        };
+        let result = service.create_commit(&msg, false).await;
+
+        assert!(result.is_ok());
+
+        let last = service.last_commit().await.unwrap();
+        assert!(last.summary.contains("quotes"));
+    });
+}
+
+#[test]
+#[serial]
+fn create_commit_unicode_message() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial");
+
+        repo.create_file("unicode.txt", "内容");
+        repo.add("unicode.txt");
+
+        let service = setup_commit_service(&repo);
+        let msg = CommitMessage {
+            title: "feat: 新機能の追加 🚀".to_string(),
+            description: None,
+            co_authors: vec![],
+        };
+        let result = service.create_commit(&msg, false).await;
+
+        assert!(result.is_ok());
+
+        let last = service.last_commit().await.unwrap();
+        assert!(last.summary.contains("新機能"));
+    });
+}
+
+#[test]
+#[serial]
+fn commit_on_different_branch() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial on main");
+
+        // Create and switch to feature branch
+        repo.create_branch("feature");
+        repo.switch_branch("feature");
+
+        repo.create_file("feature.txt", "feature content");
+        repo.add("feature.txt");
+
+        let service = setup_commit_service(&repo);
+        let msg = CommitMessage {
+            title: "Feature commit".to_string(),
+            description: None,
+            co_authors: vec![],
+        };
+        let result = service.create_commit(&msg, false).await;
+
+        assert!(result.is_ok());
+
+        // Verify commit exists on feature branch
+        let last = service.last_commit().await.unwrap();
+        assert_eq!(last.summary, "Feature commit");
+    });
+}
+
+#[test]
+#[serial]
+fn commit_with_description() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial");
+
+        repo.create_file("detailed.txt", "content");
+        repo.add("detailed.txt");
+
+        let service = setup_commit_service(&repo);
+        let msg = CommitMessage {
+            title: "Add detailed feature".to_string(),
+            description: Some("This adds a detailed feature with lots of context.\n\nMore details here.".to_string()),
+            co_authors: vec![],
+        };
+        let result = service.create_commit(&msg, false).await;
+
+        assert!(result.is_ok());
+
+        let last = service.last_commit().await.unwrap();
+        assert_eq!(last.summary, "Add detailed feature");
+    });
+}

--- a/crates/git/tests/commit_service.rs
+++ b/crates/git/tests/commit_service.rs
@@ -4,7 +4,7 @@
 
 mod common;
 
-use common::{run_async, TestRepo};
+use common::{TestRepo, run_async};
 use git::context::RepoContext;
 use git::models::commit::CommitMessage;
 use git::service::commit::CommitService;
@@ -239,7 +239,9 @@ fn get_commit_by_invalid_id() {
         repo.commit_file("README.md", "# Test", "Initial");
 
         let service = setup_commit_service(&repo);
-        let result = service.commit_by_id("0000000000000000000000000000000000000000").await;
+        let result = service
+            .commit_by_id("0000000000000000000000000000000000000000")
+            .await;
 
         // Should fail - invalid commit reference
         assert!(result.is_err());
@@ -263,7 +265,9 @@ fn create_commit_multiline_message() {
         let service = setup_commit_service(&repo);
         let msg = CommitMessage {
             title: "Subject line".to_string(),
-            description: Some("This is the body of the commit.\nIt has multiple lines.".to_string()),
+            description: Some(
+                "This is the body of the commit.\nIt has multiple lines.".to_string(),
+            ),
             co_authors: vec![],
         };
         let result = service.create_commit(&msg, false).await;
@@ -369,7 +373,10 @@ fn commit_with_description() {
         let service = setup_commit_service(&repo);
         let msg = CommitMessage {
             title: "Add detailed feature".to_string(),
-            description: Some("This adds a detailed feature with lots of context.\n\nMore details here.".to_string()),
+            description: Some(
+                "This adds a detailed feature with lots of context.\n\nMore details here."
+                    .to_string(),
+            ),
             co_authors: vec![],
         };
         let result = service.create_commit(&msg, false).await;

--- a/crates/git/tests/common/mod.rs
+++ b/crates/git/tests/common/mod.rs
@@ -1,0 +1,213 @@
+//! Test helper utilities for git crate integration tests.
+//!
+//! Provides a `TestRepo` struct that creates a temporary git repository
+//! with utilities for common git operations.
+
+#![allow(dead_code)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+/// A temporary git repository for testing purposes.
+/// Automatically cleans up on drop.
+pub struct TestRepo {
+    /// The temporary directory containing the repo.
+    pub dir: TempDir,
+}
+
+impl TestRepo {
+    /// Create a new temporary git repository.
+    pub fn new() -> Self {
+        let dir = TempDir::new().expect("failed to create temp dir");
+
+        // Initialize git repo with 'main' as initial branch
+        let output = Command::new("git")
+            .current_dir(dir.path())
+            .args(["init", "-b", "main"])
+            .output()
+            .expect("failed to run git init");
+        assert!(output.status.success(), "git init failed");
+
+        // Configure user for commits
+        let _ = Command::new("git")
+            .current_dir(dir.path())
+            .args(["config", "user.email", "test@example.com"])
+            .output();
+
+        let _ = Command::new("git")
+            .current_dir(dir.path())
+            .args(["config", "user.name", "Test User"])
+            .output();
+
+        Self { dir }
+    }
+
+    /// Get the path to the repository.
+    pub fn path(&self) -> &Path {
+        self.dir.path()
+    }
+
+    /// Get the path as a string.
+    pub fn path_str(&self) -> &str {
+        self.dir.path().to_str().expect("path is valid utf-8")
+    }
+
+    /// Create a file with the given content.
+    pub fn create_file(&self, name: &str, content: &str) -> PathBuf {
+        let file_path = self.dir.path().join(name);
+        if let Some(parent) = file_path.parent() {
+            std::fs::create_dir_all(parent).expect("failed to create parent dirs");
+        }
+        std::fs::write(&file_path, content).expect("failed to write file");
+        file_path
+    }
+
+    /// Run a git command and return stdout.
+    pub fn git(&self, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .current_dir(self.dir.path())
+            .args(args)
+            .output()
+            .expect("failed to run git command");
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            panic!("git {} failed: {}", args.join(" "), stderr);
+        }
+
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    /// Stage a file.
+    pub fn add(&self, path: &str) {
+        self.git(&["add", path]);
+    }
+
+    /// Stage all changes.
+    pub fn add_all(&self) {
+        self.git(&["add", "-A"]);
+    }
+
+    /// Create a commit with the given message.
+    pub fn commit(&self, message: &str) -> String {
+        self.git(&["commit", "-m", message])
+    }
+
+    /// Create a file, stage it, and commit.
+    pub fn commit_file(&self, name: &str, content: &str, message: &str) -> String {
+        self.create_file(name, content);
+        self.add(name);
+        self.commit(message)
+    }
+
+    /// Get the current branch name.
+    pub fn current_branch(&self) -> String {
+        self.git(&["rev-parse", "--abbrev-ref", "HEAD"])
+    }
+
+    /// Create and switch to a new branch.
+    pub fn create_branch(&self, name: &str) -> String {
+        self.git(&["switch", "-c", name])
+    }
+
+    /// Switch to an existing branch.
+    pub fn switch_branch(&self, name: &str) -> String {
+        self.git(&["switch", name])
+    }
+
+    /// Get the HEAD commit hash.
+    pub fn head_commit(&self) -> String {
+        self.git(&["rev-parse", "HEAD"])
+    }
+
+    /// List all local branches.
+    pub fn list_branches(&self) -> Vec<String> {
+        self.git(&["branch", "--list", "--format=%(refname:short)"])
+            .lines()
+            .map(|s| s.to_string())
+            .collect()
+    }
+
+    /// Create a stash (includes untracked files).
+    pub fn stash_push(&self, message: Option<&str>) -> String {
+        match message {
+            Some(msg) => self.git(&["stash", "push", "-u", "-m", msg]),
+            None => self.git(&["stash", "push", "-u"]),
+        }
+    }
+
+    /// List stashes.
+    pub fn stash_list(&self) -> String {
+        self.git(&["stash", "list"])
+    }
+
+    /// Check if there are uncommitted changes.
+    pub fn has_changes(&self) -> bool {
+        let status = self.git(&["status", "--porcelain"]);
+        !status.is_empty()
+    }
+
+    /// Check if a file is staged.
+    pub fn is_staged(&self, path: &str) -> bool {
+        let output = Command::new("git")
+            .current_dir(self.dir.path())
+            .args(["diff", "--cached", "--name-only"])
+            .output()
+            .expect("failed to run git diff");
+
+        let staged = String::from_utf8_lossy(&output.stdout);
+        staged.lines().any(|l| l == path || l.ends_with(path))
+    }
+
+    /// Get the HEAD commit hash.
+    pub fn get_head_hash(&self) -> String {
+        self.git(&["rev-parse", "HEAD"])
+    }
+
+    /// Set up a bare remote repository and add it as origin.
+    pub fn setup_remote(&self) -> TempDir {
+        let remote_dir = TempDir::new().expect("failed to create remote temp dir");
+
+        // Initialize bare repo
+        Command::new("git")
+            .current_dir(remote_dir.path())
+            .args(["init", "--bare"])
+            .output()
+            .expect("failed to init bare repo");
+
+        // Add as remote
+        let remote_url = remote_dir.path().to_str().unwrap();
+        self.git(&["remote", "add", "origin", remote_url]);
+
+        remote_dir
+    }
+
+    /// Push to origin.
+    pub fn push(&self, branch: &str) -> String {
+        self.git(&["push", "-u", "origin", branch])
+    }
+
+    /// Fetch from origin.
+    pub fn fetch(&self) -> String {
+        self.git(&["fetch", "--all"])
+    }
+}
+
+impl Default for TestRepo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Run an async test using tokio's current_thread runtime.
+pub fn run_async<F>(f: F)
+where
+    F: std::future::Future<Output = ()>,
+{
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("failed to create runtime")
+        .block_on(f);
+}

--- a/crates/git/tests/parser_integration.rs
+++ b/crates/git/tests/parser_integration.rs
@@ -26,7 +26,7 @@ fn parse_real_commit_simple() {
     let repo = TestRepo::new();
     repo.commit_file("README.md", "# Hello", "Initial commit");
 
-    let output = repo.git(&["log", "-1", &format!("--format={}", COMMIT_STANDARD_FORMAT)]);
+    let output = repo.git(&["log", "-1", &format!("--format={COMMIT_STANDARD_FORMAT}")]);
 
     let commit = parse_commit_record(&output).unwrap();
     assert_eq!(commit.summary, "Initial commit");
@@ -48,7 +48,7 @@ fn parse_real_commit_with_body() {
         "Add feature\n\nThis is the body.\nWith multiple lines.",
     ]);
 
-    let output = repo.git(&["log", "-1", &format!("--format={}", COMMIT_STANDARD_FORMAT)]);
+    let output = repo.git(&["log", "-1", &format!("--format={COMMIT_STANDARD_FORMAT}")]);
 
     let commit = parse_commit_record(&output).unwrap();
     assert_eq!(commit.summary, "Add feature");
@@ -66,7 +66,7 @@ fn parse_real_commit_with_co_authors() {
     let message = "Add feature\n\nImplementation details.\n\nCo-authored-by: Alice <alice@example.com>\nCo-authored-by: Bob <bob@example.com>";
     repo.git(&["commit", "-m", message]);
 
-    let output = repo.git(&["log", "-1", &format!("--format={}", COMMIT_STANDARD_FORMAT)]);
+    let output = repo.git(&["log", "-1", &format!("--format={COMMIT_STANDARD_FORMAT}")]);
 
     let commit = parse_commit_record(&output).unwrap();
     assert_eq!(commit.authors.co_authors.len(), 2);
@@ -82,7 +82,7 @@ fn parse_real_commit_unicode_message() {
     let repo = TestRepo::new();
     repo.commit_file("日本語.txt", "こんにちは", "日本語のコミットメッセージ 🎉");
 
-    let output = repo.git(&["log", "-1", &format!("--format={}", COMMIT_STANDARD_FORMAT)]);
+    let output = repo.git(&["log", "-1", &format!("--format={COMMIT_STANDARD_FORMAT}")]);
 
     let commit = parse_commit_record(&output).unwrap();
     assert!(commit.summary.contains("日本語"));
@@ -219,7 +219,7 @@ fn parse_real_single_branch() {
     let output = repo.git(&[
         "for-each-ref",
         "refs/heads",
-        &format!("--format={}", BRANCH_STANDARD_FORMAT),
+        &format!("--format={BRANCH_STANDARD_FORMAT}"),
     ]);
 
     let branches = parse_branch_records(&output, false).unwrap();
@@ -243,7 +243,7 @@ fn parse_real_multiple_branches() {
     let output = repo.git(&[
         "for-each-ref",
         "refs/heads",
-        &format!("--format={}", BRANCH_STANDARD_FORMAT),
+        &format!("--format={BRANCH_STANDARD_FORMAT}"),
     ]);
 
     let branches = parse_branch_records(&output, false).unwrap();
@@ -266,7 +266,7 @@ fn parse_real_branch_after_switch() {
     let output = repo.git(&[
         "for-each-ref",
         "refs/heads",
-        &format!("--format={}", BRANCH_STANDARD_FORMAT),
+        &format!("--format={BRANCH_STANDARD_FORMAT}"),
     ]);
 
     let branches = parse_branch_records(&output, false).unwrap();
@@ -288,7 +288,7 @@ fn parse_real_branch_with_commit_info() {
     let output = repo.git(&[
         "for-each-ref",
         "refs/heads",
-        &format!("--format={}", BRANCH_STANDARD_FORMAT),
+        &format!("--format={BRANCH_STANDARD_FORMAT}"),
     ]);
 
     let branches = parse_branch_records(&output, false).unwrap();
@@ -310,7 +310,7 @@ fn parse_real_branch_unicode_name() {
     let output = repo.git(&[
         "for-each-ref",
         "refs/heads",
-        &format!("--format={}", BRANCH_STANDARD_FORMAT),
+        &format!("--format={BRANCH_STANDARD_FORMAT}"),
     ]);
 
     let branches = parse_branch_records(&output, false).unwrap();
@@ -509,7 +509,7 @@ fn parse_real_history_single_commit() {
     let repo = TestRepo::new();
     repo.commit_file("README.md", "# Test", "Initial commit");
 
-    let output = repo.git(&["log", &format!("--format={}", COMMIT_STANDARD_FORMAT)]);
+    let output = repo.git(&["log", &format!("--format={COMMIT_STANDARD_FORMAT}")]);
 
     let commits = parse_history_records(&output).unwrap();
     assert_eq!(commits.len(), 1);
@@ -524,7 +524,7 @@ fn parse_real_history_multiple_commits() {
     repo.commit_file("file2.txt", "2", "Second commit");
     repo.commit_file("file3.txt", "3", "Third commit");
 
-    let output = repo.git(&["log", &format!("--format={}", COMMIT_STANDARD_FORMAT)]);
+    let output = repo.git(&["log", &format!("--format={COMMIT_STANDARD_FORMAT}")]);
 
     let commits = parse_history_records(&output).unwrap();
     assert_eq!(commits.len(), 3);
@@ -541,13 +541,13 @@ fn parse_real_history_preserves_order() {
     let repo = TestRepo::new();
     for i in 1..=5 {
         repo.commit_file(
-            &format!("file{}.txt", i),
+            &format!("file{i}.txt"),
             &i.to_string(),
-            &format!("Commit {}", i),
+            &format!("Commit {i}"),
         );
     }
 
-    let output = repo.git(&["log", &format!("--format={}", COMMIT_STANDARD_FORMAT)]);
+    let output = repo.git(&["log", &format!("--format={COMMIT_STANDARD_FORMAT}")]);
 
     let commits = parse_history_records(&output).unwrap();
     assert_eq!(commits.len(), 5);
@@ -563,13 +563,13 @@ fn parse_real_history_with_limit() {
     let repo = TestRepo::new();
     for i in 1..=10 {
         repo.commit_file(
-            &format!("file{}.txt", i),
+            &format!("file{i}.txt"),
             &i.to_string(),
-            &format!("Commit {}", i),
+            &format!("Commit {i}"),
         );
     }
 
-    let output = repo.git(&["log", "-5", &format!("--format={}", COMMIT_STANDARD_FORMAT)]);
+    let output = repo.git(&["log", "-5", &format!("--format={COMMIT_STANDARD_FORMAT}")]);
 
     let commits = parse_history_records(&output).unwrap();
     assert_eq!(commits.len(), 5);

--- a/crates/git/tests/parser_integration.rs
+++ b/crates/git/tests/parser_integration.rs
@@ -1,0 +1,753 @@
+//! Integration tests for parsers using real git repositories.
+//!
+//! These tests create actual git repositories and parse real git output,
+//! ensuring our parsers work with authentic git data rather than synthetic mocks.
+
+mod common;
+
+use common::TestRepo;
+use git::parsers::branch::{BRANCH_STANDARD_FORMAT, parse_branch_records};
+use git::parsers::commit::{
+    COMMIT_STANDARD_FORMAT, build_commit_authors, extract_co_authors, normalize_email,
+    parse_commit_record, parse_shortstat,
+};
+use git::parsers::history::parse_history_records;
+use git::parsers::stash::{parse_stash_file_status, parse_stash_list, parse_stash_stat};
+use git::parsers::status::parse_porcelain_v2;
+use serial_test::serial;
+
+// ══════════════════════════════════════════════════════════════════════════════
+// COMMIT PARSER TESTS - Real Git Output
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[serial]
+fn parse_real_commit_simple() {
+    let repo = TestRepo::new();
+    repo.commit_file("README.md", "# Hello", "Initial commit");
+
+    let output = repo.git(&["log", "-1", &format!("--format={}", COMMIT_STANDARD_FORMAT)]);
+
+    let commit = parse_commit_record(&output).unwrap();
+    assert_eq!(commit.summary, "Initial commit");
+    assert_eq!(commit.authors.author.name, "Test User");
+    assert_eq!(commit.authors.author.email, "test@example.com");
+    assert!(!commit.id.is_empty());
+    assert!(commit.timestamp > 0);
+}
+
+#[test]
+#[serial]
+fn parse_real_commit_with_body() {
+    let repo = TestRepo::new();
+    repo.create_file("file.txt", "content");
+    repo.add("file.txt");
+    repo.git(&[
+        "commit",
+        "-m",
+        "Add feature\n\nThis is the body.\nWith multiple lines.",
+    ]);
+
+    let output = repo.git(&["log", "-1", &format!("--format={}", COMMIT_STANDARD_FORMAT)]);
+
+    let commit = parse_commit_record(&output).unwrap();
+    assert_eq!(commit.summary, "Add feature");
+    assert!(commit.body.contains("This is the body"));
+    assert!(commit.body.contains("multiple lines"));
+}
+
+#[test]
+#[serial]
+fn parse_real_commit_with_co_authors() {
+    let repo = TestRepo::new();
+    repo.create_file("file.txt", "content");
+    repo.add("file.txt");
+
+    let message = "Add feature\n\nImplementation details.\n\nCo-authored-by: Alice <alice@example.com>\nCo-authored-by: Bob <bob@example.com>";
+    repo.git(&["commit", "-m", message]);
+
+    let output = repo.git(&["log", "-1", &format!("--format={}", COMMIT_STANDARD_FORMAT)]);
+
+    let commit = parse_commit_record(&output).unwrap();
+    assert_eq!(commit.authors.co_authors.len(), 2);
+    assert_eq!(commit.authors.co_authors[0].name, "Alice");
+    assert_eq!(commit.authors.co_authors[0].email, "alice@example.com");
+    assert_eq!(commit.authors.co_authors[1].name, "Bob");
+    assert_eq!(commit.authors.co_authors[1].email, "bob@example.com");
+}
+
+#[test]
+#[serial]
+fn parse_real_commit_unicode_message() {
+    let repo = TestRepo::new();
+    repo.commit_file("日本語.txt", "こんにちは", "日本語のコミットメッセージ 🎉");
+
+    let output = repo.git(&["log", "-1", &format!("--format={}", COMMIT_STANDARD_FORMAT)]);
+
+    let commit = parse_commit_record(&output).unwrap();
+    assert!(commit.summary.contains("日本語"));
+}
+
+#[test]
+#[serial]
+fn parse_real_shortstat() {
+    let repo = TestRepo::new();
+    repo.commit_file("README.md", "# Hello", "Initial commit");
+
+    // Make changes
+    repo.create_file("file1.txt", "line1\nline2\nline3");
+    repo.create_file("file2.txt", "content");
+    repo.add(".");
+    repo.commit("Add files");
+
+    let output = repo.git(&["diff", "--shortstat", "HEAD~1", "HEAD"]);
+    let stats = parse_shortstat(&output);
+
+    assert_eq!(stats.files_changed, 2);
+    assert!(stats.insertions > 0);
+}
+
+#[test]
+#[serial]
+fn parse_real_shortstat_with_deletions() {
+    let repo = TestRepo::new();
+    repo.commit_file("file.txt", "line1\nline2\nline3\nline4\nline5", "Initial");
+
+    // Modify - remove some lines
+    repo.create_file("file.txt", "line1\nline3");
+    repo.add(".");
+    repo.commit("Remove lines");
+
+    let output = repo.git(&["diff", "--shortstat", "HEAD~1", "HEAD"]);
+    let stats = parse_shortstat(&output);
+
+    assert_eq!(stats.files_changed, 1);
+    assert!(stats.deletions > 0);
+}
+
+#[test]
+#[serial]
+fn parse_real_shortstat_insertions_only() {
+    let repo = TestRepo::new();
+    repo.commit_file("README.md", "# Test", "Initial commit");
+
+    // Add a brand new file with content (no deletions)
+    repo.commit_file(
+        "new_feature.txt",
+        "line1\nline2\nline3\nline4\nline5",
+        "Add new feature file",
+    );
+
+    let output = repo.git(&["diff", "--shortstat", "HEAD~1", "HEAD"]);
+    let stats = parse_shortstat(&output);
+
+    assert_eq!(stats.files_changed, 1);
+    assert_eq!(stats.insertions, 5);
+    assert_eq!(stats.deletions, 0);
+}
+
+#[test]
+#[serial]
+fn parse_real_shortstat_deletions_only() {
+    let repo = TestRepo::new();
+    repo.commit_file("to_delete.txt", "line1\nline2\nline3", "Initial");
+
+    // Delete the file entirely
+    std::fs::remove_file(repo.path().join("to_delete.txt")).unwrap();
+    repo.add(".");
+    repo.commit("Delete file");
+
+    let output = repo.git(&["diff", "--shortstat", "HEAD~1", "HEAD"]);
+    let stats = parse_shortstat(&output);
+
+    assert_eq!(stats.files_changed, 1);
+    assert_eq!(stats.insertions, 0);
+    assert_eq!(stats.deletions, 3);
+}
+
+#[test]
+#[serial]
+fn parse_real_shortstat_multiple_files() {
+    let repo = TestRepo::new();
+    repo.commit_file("README.md", "# Test", "Initial commit");
+
+    // Add multiple files of different sizes
+    repo.create_file("small.txt", "a");
+    repo.create_file("medium.txt", "line1\nline2\nline3");
+    repo.create_file("large.txt", "1\n2\n3\n4\n5\n6\n7\n8\n9\n10");
+    repo.add(".");
+    repo.commit("Add multiple files");
+
+    let output = repo.git(&["diff", "--shortstat", "HEAD~1", "HEAD"]);
+    let stats = parse_shortstat(&output);
+
+    assert_eq!(stats.files_changed, 3);
+    assert_eq!(stats.insertions, 14); // 1 + 3 + 10
+    assert_eq!(stats.deletions, 0);
+}
+
+#[test]
+#[serial]
+fn parse_real_shortstat_single_insertion() {
+    let repo = TestRepo::new();
+    repo.commit_file("file.txt", "original", "Initial");
+
+    // Add exactly one line
+    repo.create_file("file.txt", "original\nnew line");
+    repo.add(".");
+    repo.commit("Add one line");
+
+    let output = repo.git(&["diff", "--shortstat", "HEAD~1", "HEAD"]);
+    let stats = parse_shortstat(&output);
+
+    assert_eq!(stats.files_changed, 1);
+    // Git counts the modified line as changed, so this might be 1 insertion + 1 deletion
+    // depending on how git sees the diff
+    assert!(stats.insertions >= 1);
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// BRANCH PARSER TESTS - Real Git Output
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[serial]
+fn parse_real_single_branch() {
+    let repo = TestRepo::new();
+    repo.commit_file("README.md", "# Test", "Initial commit");
+
+    let output = repo.git(&[
+        "for-each-ref",
+        "refs/heads",
+        &format!("--format={}", BRANCH_STANDARD_FORMAT),
+    ]);
+
+    let branches = parse_branch_records(&output, false).unwrap();
+    assert_eq!(branches.len(), 1);
+    assert_eq!(branches[0].name, "main");
+    assert!(branches[0].is_head);
+    assert!(!branches[0].is_remote);
+}
+
+#[test]
+#[serial]
+fn parse_real_multiple_branches() {
+    let repo = TestRepo::new();
+    repo.commit_file("README.md", "# Test", "Initial commit");
+
+    // Create branches
+    repo.git(&["branch", "feature/one"]);
+    repo.git(&["branch", "feature/two"]);
+    repo.git(&["branch", "bugfix/issue-123"]);
+
+    let output = repo.git(&[
+        "for-each-ref",
+        "refs/heads",
+        &format!("--format={}", BRANCH_STANDARD_FORMAT),
+    ]);
+
+    let branches = parse_branch_records(&output, false).unwrap();
+    assert_eq!(branches.len(), 4);
+
+    let names: Vec<&str> = branches.iter().map(|b| b.name.as_str()).collect();
+    assert!(names.contains(&"main"));
+    assert!(names.contains(&"feature/one"));
+    assert!(names.contains(&"feature/two"));
+    assert!(names.contains(&"bugfix/issue-123"));
+}
+
+#[test]
+#[serial]
+fn parse_real_branch_after_switch() {
+    let repo = TestRepo::new();
+    repo.commit_file("README.md", "# Test", "Initial commit");
+    repo.create_branch("feature/current");
+
+    let output = repo.git(&[
+        "for-each-ref",
+        "refs/heads",
+        &format!("--format={}", BRANCH_STANDARD_FORMAT),
+    ]);
+
+    let branches = parse_branch_records(&output, false).unwrap();
+
+    // Find the current branch
+    let current = branches.iter().find(|b| b.is_head);
+    assert!(current.is_some());
+    assert_eq!(current.unwrap().name, "feature/current");
+}
+
+#[test]
+#[serial]
+fn parse_real_branch_with_commit_info() {
+    let repo = TestRepo::new();
+    repo.commit_file("README.md", "# Test", "Initial commit on main");
+    repo.create_branch("feature");
+    repo.commit_file("feature.txt", "feature", "Feature commit");
+
+    let output = repo.git(&[
+        "for-each-ref",
+        "refs/heads",
+        &format!("--format={}", BRANCH_STANDARD_FORMAT),
+    ]);
+
+    let branches = parse_branch_records(&output, false).unwrap();
+
+    let feature_branch = branches.iter().find(|b| b.name == "feature").unwrap();
+    assert_eq!(feature_branch.commit.summary, "Feature commit");
+    assert!(!feature_branch.commit.id.is_empty());
+}
+
+#[test]
+#[serial]
+fn parse_real_branch_unicode_name() {
+    let repo = TestRepo::new();
+    repo.commit_file("README.md", "# Test", "Initial commit");
+
+    // Create branch with unicode characters
+    repo.git(&["branch", "feature/新機能"]);
+
+    let output = repo.git(&[
+        "for-each-ref",
+        "refs/heads",
+        &format!("--format={}", BRANCH_STANDARD_FORMAT),
+    ]);
+
+    let branches = parse_branch_records(&output, false).unwrap();
+    let names: Vec<&str> = branches.iter().map(|b| b.name.as_str()).collect();
+    assert!(names.contains(&"feature/新機能"));
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// STATUS PARSER TESTS - Real Git Output
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[serial]
+fn parse_real_status_clean() {
+    let repo = TestRepo::new();
+    repo.commit_file("README.md", "# Test", "Initial commit");
+
+    let output = repo.git(&["status", "--porcelain=v2", "-z"]);
+    let statuses = parse_porcelain_v2(output.as_bytes()).unwrap();
+
+    assert!(statuses.is_empty());
+}
+
+#[test]
+#[serial]
+fn parse_real_status_untracked() {
+    let repo = TestRepo::new();
+    repo.commit_file("README.md", "# Test", "Initial commit");
+    repo.create_file("untracked.txt", "new file");
+
+    let output = repo.git(&["status", "--porcelain=v2", "-z"]);
+    let statuses = parse_porcelain_v2(output.as_bytes()).unwrap();
+
+    assert_eq!(statuses.len(), 1);
+    assert_eq!(statuses[0].path, "untracked.txt");
+    assert!(
+        statuses[0]
+            .status
+            .iter()
+            .any(|s| matches!(s, git::models::status::FileStatusKind::WorktreeNew))
+    );
+}
+
+#[test]
+#[serial]
+fn parse_real_status_staged_new() {
+    let repo = TestRepo::new();
+    repo.commit_file("README.md", "# Test", "Initial commit");
+    repo.create_file("new.txt", "content");
+    repo.add("new.txt");
+
+    let output = repo.git(&["status", "--porcelain=v2", "-z"]);
+    let statuses = parse_porcelain_v2(output.as_bytes()).unwrap();
+
+    assert_eq!(statuses.len(), 1);
+    assert!(
+        statuses[0]
+            .status
+            .iter()
+            .any(|s| matches!(s, git::models::status::FileStatusKind::IndexNew))
+    );
+}
+
+#[test]
+#[serial]
+fn parse_real_status_modified_worktree() {
+    let repo = TestRepo::new();
+    repo.commit_file("file.txt", "original", "Initial commit");
+    repo.create_file("file.txt", "modified");
+
+    let output = repo.git(&["status", "--porcelain=v2", "-z"]);
+    let statuses = parse_porcelain_v2(output.as_bytes()).unwrap();
+
+    assert_eq!(statuses.len(), 1);
+    assert!(
+        statuses[0]
+            .status
+            .iter()
+            .any(|s| matches!(s, git::models::status::FileStatusKind::WorktreeModified))
+    );
+}
+
+#[test]
+#[serial]
+fn parse_real_status_modified_staged() {
+    let repo = TestRepo::new();
+    repo.commit_file("file.txt", "original", "Initial commit");
+    repo.create_file("file.txt", "modified");
+    repo.add("file.txt");
+
+    let output = repo.git(&["status", "--porcelain=v2", "-z"]);
+    let statuses = parse_porcelain_v2(output.as_bytes()).unwrap();
+
+    assert_eq!(statuses.len(), 1);
+    assert!(
+        statuses[0]
+            .status
+            .iter()
+            .any(|s| matches!(s, git::models::status::FileStatusKind::IndexModified))
+    );
+}
+
+#[test]
+#[serial]
+fn parse_real_status_deleted() {
+    let repo = TestRepo::new();
+    repo.commit_file("file.txt", "content", "Initial commit");
+    std::fs::remove_file(repo.path().join("file.txt")).unwrap();
+
+    let output = repo.git(&["status", "--porcelain=v2", "-z"]);
+    let statuses = parse_porcelain_v2(output.as_bytes()).unwrap();
+
+    assert_eq!(statuses.len(), 1);
+    assert!(
+        statuses[0]
+            .status
+            .iter()
+            .any(|s| matches!(s, git::models::status::FileStatusKind::WorktreeDeleted))
+    );
+}
+
+#[test]
+#[serial]
+fn parse_real_status_renamed() {
+    let repo = TestRepo::new();
+    repo.commit_file("old_name.txt", "content", "Initial commit");
+    repo.git(&["mv", "old_name.txt", "new_name.txt"]);
+
+    let output = repo.git(&["status", "--porcelain=v2", "-z"]);
+    let statuses = parse_porcelain_v2(output.as_bytes()).unwrap();
+
+    assert_eq!(statuses.len(), 1);
+    assert_eq!(statuses[0].path, "old_name.txt");
+    assert_eq!(statuses[0].new_path, Some("new_name.txt".to_string()));
+    assert!(
+        statuses[0]
+            .status
+            .iter()
+            .any(|s| matches!(s, git::models::status::FileStatusKind::IndexRenamed))
+    );
+}
+
+#[test]
+#[serial]
+fn parse_real_status_multiple_files() {
+    let repo = TestRepo::new();
+    repo.commit_file("README.md", "# Test", "Initial commit");
+
+    repo.create_file("untracked.txt", "untracked");
+    repo.create_file("staged.txt", "staged");
+    repo.add("staged.txt");
+    repo.create_file("README.md", "# Modified");
+
+    let output = repo.git(&["status", "--porcelain=v2", "-z"]);
+    let statuses = parse_porcelain_v2(output.as_bytes()).unwrap();
+
+    assert_eq!(statuses.len(), 3);
+}
+
+#[test]
+#[serial]
+fn parse_real_status_file_with_spaces() {
+    let repo = TestRepo::new();
+    repo.commit_file("README.md", "# Test", "Initial commit");
+    repo.create_file("file with spaces.txt", "content");
+
+    let output = repo.git(&["status", "--porcelain=v2", "-z"]);
+    let statuses = parse_porcelain_v2(output.as_bytes()).unwrap();
+
+    assert_eq!(statuses.len(), 1);
+    assert_eq!(statuses[0].path, "file with spaces.txt");
+}
+
+#[test]
+#[serial]
+fn parse_real_status_nested_directory() {
+    let repo = TestRepo::new();
+    repo.commit_file("README.md", "# Test", "Initial commit");
+    repo.create_file("src/nested/deep/file.txt", "content");
+
+    // Use -uall to show individual files instead of directory summaries
+    let output = repo.git(&["status", "--porcelain=v2", "-z", "-uall"]);
+    let statuses = parse_porcelain_v2(output.as_bytes()).unwrap();
+
+    assert_eq!(statuses.len(), 1);
+    assert_eq!(statuses[0].path, "src/nested/deep/file.txt");
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// HISTORY PARSER TESTS - Real Git Output
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[serial]
+fn parse_real_history_single_commit() {
+    let repo = TestRepo::new();
+    repo.commit_file("README.md", "# Test", "Initial commit");
+
+    let output = repo.git(&["log", &format!("--format={}", COMMIT_STANDARD_FORMAT)]);
+
+    let commits = parse_history_records(&output).unwrap();
+    assert_eq!(commits.len(), 1);
+    assert_eq!(commits[0].summary, "Initial commit");
+}
+
+#[test]
+#[serial]
+fn parse_real_history_multiple_commits() {
+    let repo = TestRepo::new();
+    repo.commit_file("file1.txt", "1", "First commit");
+    repo.commit_file("file2.txt", "2", "Second commit");
+    repo.commit_file("file3.txt", "3", "Third commit");
+
+    let output = repo.git(&["log", &format!("--format={}", COMMIT_STANDARD_FORMAT)]);
+
+    let commits = parse_history_records(&output).unwrap();
+    assert_eq!(commits.len(), 3);
+
+    // Git log shows newest first
+    assert_eq!(commits[0].summary, "Third commit");
+    assert_eq!(commits[1].summary, "Second commit");
+    assert_eq!(commits[2].summary, "First commit");
+}
+
+#[test]
+#[serial]
+fn parse_real_history_preserves_order() {
+    let repo = TestRepo::new();
+    for i in 1..=5 {
+        repo.commit_file(
+            &format!("file{}.txt", i),
+            &i.to_string(),
+            &format!("Commit {}", i),
+        );
+    }
+
+    let output = repo.git(&["log", &format!("--format={}", COMMIT_STANDARD_FORMAT)]);
+
+    let commits = parse_history_records(&output).unwrap();
+    assert_eq!(commits.len(), 5);
+
+    // Verify reverse chronological order
+    assert_eq!(commits[0].summary, "Commit 5");
+    assert_eq!(commits[4].summary, "Commit 1");
+}
+
+#[test]
+#[serial]
+fn parse_real_history_with_limit() {
+    let repo = TestRepo::new();
+    for i in 1..=10 {
+        repo.commit_file(
+            &format!("file{}.txt", i),
+            &i.to_string(),
+            &format!("Commit {}", i),
+        );
+    }
+
+    let output = repo.git(&["log", "-5", &format!("--format={}", COMMIT_STANDARD_FORMAT)]);
+
+    let commits = parse_history_records(&output).unwrap();
+    assert_eq!(commits.len(), 5);
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// STASH PARSER TESTS - Real Git Output
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[serial]
+fn parse_real_stash_list_empty() {
+    let repo = TestRepo::new();
+    repo.commit_file("README.md", "# Test", "Initial commit");
+
+    let output = repo.git(&["stash", "list", "--format=%gd%x1f%gs"]);
+    let stashes = parse_stash_list(&output).unwrap();
+
+    assert!(stashes.is_empty());
+}
+
+#[test]
+#[serial]
+fn parse_real_stash_list_single() {
+    let repo = TestRepo::new();
+    repo.commit_file("README.md", "# Test", "Initial commit");
+
+    repo.create_file("changes.txt", "uncommitted");
+    repo.add("changes.txt");
+    repo.git(&["stash", "push", "-m", "Work in progress"]);
+
+    let output = repo.git(&["stash", "list", "--format=%gd%x1f%gs"]);
+    let stashes = parse_stash_list(&output).unwrap();
+
+    assert_eq!(stashes.len(), 1);
+    assert_eq!(stashes[0].index, 0);
+    assert_eq!(stashes[0].reference, "stash@{0}");
+    assert!(stashes[0].message.contains("Work in progress"));
+}
+
+#[test]
+#[serial]
+fn parse_real_stash_list_multiple() {
+    let repo = TestRepo::new();
+    repo.commit_file("README.md", "# Test", "Initial commit");
+
+    // Create multiple stashes
+    repo.create_file("file1.txt", "1");
+    repo.add("file1.txt");
+    repo.git(&["stash", "push", "-m", "First stash"]);
+
+    repo.create_file("file2.txt", "2");
+    repo.add("file2.txt");
+    repo.git(&["stash", "push", "-m", "Second stash"]);
+
+    repo.create_file("file3.txt", "3");
+    repo.add("file3.txt");
+    repo.git(&["stash", "push", "-m", "Third stash"]);
+
+    let output = repo.git(&["stash", "list", "--format=%gd%x1f%gs"]);
+    let stashes = parse_stash_list(&output).unwrap();
+
+    assert_eq!(stashes.len(), 3);
+    assert_eq!(stashes[0].index, 0);
+    assert_eq!(stashes[1].index, 1);
+    assert_eq!(stashes[2].index, 2);
+
+    // Most recent stash is first
+    assert!(stashes[0].message.contains("Third stash"));
+    assert!(stashes[2].message.contains("First stash"));
+}
+
+#[test]
+#[serial]
+fn parse_real_stash_stat() {
+    let repo = TestRepo::new();
+    repo.commit_file("README.md", "# Test", "Initial commit");
+
+    repo.create_file("new_file.txt", "line1\nline2\nline3");
+    repo.add("new_file.txt");
+    repo.git(&["stash", "push", "-m", "Stash with stats"]);
+
+    let output = repo.git(&["stash", "show", "--stat", "stash@{0}"]);
+    let stat = parse_stash_stat(&output, "stash@{0}").unwrap();
+
+    assert_eq!(stat.reference, "stash@{0}");
+    assert_eq!(stat.files_changed, 1);
+    assert!(stat.insertions > 0);
+}
+
+#[test]
+#[serial]
+fn parse_real_stash_file_status() {
+    let repo = TestRepo::new();
+    repo.commit_file("README.md", "# Test", "Initial commit");
+
+    repo.create_file("added.txt", "new");
+    repo.add("added.txt");
+    repo.git(&["stash", "push", "-m", "Test stash"]);
+
+    let output_str = repo.git(&["stash", "show", "--name-status", "-z", "stash@{0}"]);
+    let statuses = parse_stash_file_status(output_str.as_bytes()).unwrap();
+
+    assert!(!statuses.is_empty());
+}
+
+#[test]
+#[serial]
+fn parse_real_stash_with_modifications() {
+    let repo = TestRepo::new();
+    repo.commit_file("file.txt", "original", "Initial commit");
+
+    // Modify and stash
+    repo.create_file("file.txt", "modified\nwith extra lines");
+    repo.add("file.txt");
+    repo.git(&["stash", "push", "-m", "Modified file"]);
+
+    let output = repo.git(&["stash", "show", "--stat", "stash@{0}"]);
+    let stat = parse_stash_stat(&output, "stash@{0}").unwrap();
+
+    assert_eq!(stat.files_changed, 1);
+    assert!(stat.insertions > 0 || stat.deletions > 0);
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// HELPER FUNCTION TESTS - These can remain with synthetic data
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn normalize_email_removes_brackets() {
+    assert_eq!(normalize_email("<alice@example.com>"), "alice@example.com");
+    assert_eq!(normalize_email("  <bob@test.org>  "), "bob@test.org");
+    assert_eq!(normalize_email("plain@email.com"), "plain@email.com");
+}
+
+#[test]
+fn extract_co_authors_from_message() {
+    let message = "Feature\n\nCo-authored-by: Alice <alice@example.com>\nCo-authored-by: Bob <bob@example.com>";
+    let authors = extract_co_authors(message);
+
+    assert_eq!(authors.len(), 2);
+    assert_eq!(authors[0].name, "Alice");
+    assert_eq!(authors[1].name, "Bob");
+}
+
+#[test]
+fn extract_co_authors_empty() {
+    let message = "Just a regular commit";
+    let authors = extract_co_authors(message);
+    assert!(authors.is_empty());
+}
+
+#[test]
+fn build_commit_authors_simple() {
+    let authors = build_commit_authors(
+        "Alice",
+        "alice@example.com",
+        "Alice",
+        "alice@example.com",
+        "Simple commit",
+    );
+
+    assert_eq!(authors.author.name, "Alice");
+    assert_eq!(authors.committer.name, "Alice");
+    assert!(authors.co_authors.is_empty());
+}
+
+#[test]
+fn build_commit_authors_with_co_authors() {
+    let message = "Feature\n\nCo-authored-by: Bob <bob@example.com>";
+    let authors = build_commit_authors(
+        "Alice",
+        "alice@example.com",
+        "Alice",
+        "alice@example.com",
+        message,
+    );
+
+    assert_eq!(authors.co_authors.len(), 1);
+    assert_eq!(authors.co_authors[0].name, "Bob");
+}

--- a/crates/git/tests/stash_service.rs
+++ b/crates/git/tests/stash_service.rs
@@ -369,8 +369,8 @@ fn stash_clear_all() {
 
         // Create multiple stashes
         for i in 1..=3 {
-            repo.create_file(&format!("file{}.txt", i), "content");
-            repo.stash_push(Some(&format!("Stash {}", i)));
+            repo.create_file(&format!("file{i}.txt"), "content");
+            repo.stash_push(Some(&format!("Stash {i}")));
         }
 
         let service = setup_stash_service(&repo);

--- a/crates/git/tests/stash_service.rs
+++ b/crates/git/tests/stash_service.rs
@@ -1,0 +1,554 @@
+//! Integration tests for StashService.
+//!
+//! Tests stash push/pop, apply, drop, and gitru-specific stash features.
+
+mod common;
+
+use common::{TestRepo, run_async};
+use git::context::RepoContext;
+use git::service::stash::StashService;
+use serial_test::serial;
+use std::sync::Arc;
+
+fn setup_stash_service(repo: &TestRepo) -> StashService {
+    let ctx = Arc::new(RepoContext::new(repo.path_str()).expect("failed to create repo context"));
+    StashService::new(ctx)
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// STASH LIST TESTS
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[serial]
+fn stash_list_empty() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+
+        let service = setup_stash_service(&repo);
+        let stashes = service.list().await.unwrap();
+
+        assert!(stashes.is_empty());
+    });
+}
+
+#[test]
+#[serial]
+fn stash_list_single_stash() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        repo.create_file("changes.txt", "content");
+        repo.stash_push(Some("Test stash"));
+
+        let service = setup_stash_service(&repo);
+        let stashes = service.list().await.unwrap();
+
+        assert_eq!(stashes.len(), 1);
+        assert!(stashes[0].message.contains("Test stash"));
+        assert_eq!(stashes[0].index, 0);
+        assert_eq!(stashes[0].reference, "stash@{0}");
+    });
+}
+
+#[test]
+#[serial]
+fn stash_list_multiple_stashes() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+
+        // Create first stash
+        repo.create_file("file1.txt", "content1");
+        repo.stash_push(Some("First stash"));
+
+        // Create second stash
+        repo.create_file("file2.txt", "content2");
+        repo.stash_push(Some("Second stash"));
+
+        // Create third stash
+        repo.create_file("file3.txt", "content3");
+        repo.stash_push(Some("Third stash"));
+
+        let service = setup_stash_service(&repo);
+        let stashes = service.list().await.unwrap();
+
+        assert_eq!(stashes.len(), 3);
+        // Most recent stash is at index 0
+        assert!(stashes[0].message.contains("Third stash"));
+        assert!(stashes[1].message.contains("Second stash"));
+        assert!(stashes[2].message.contains("First stash"));
+    });
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// STASH PUSH TESTS
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[serial]
+fn stash_push_simple() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        // Create a tracked change (not untracked) by modifying a committed file
+        repo.create_file("README.md", "# Test - Modified");
+
+        let service = setup_stash_service(&repo);
+        let result = service.push(Some("My stash"), false).await;
+
+        assert!(result.is_ok());
+
+        // Working tree should be clean
+        assert!(!repo.has_changes());
+
+        // Should have one stash
+        let stashes = service.list().await.unwrap();
+        assert_eq!(stashes.len(), 1);
+    });
+}
+
+#[test]
+#[serial]
+fn stash_push_with_untracked() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        repo.create_file("untracked.txt", "untracked content");
+
+        let service = setup_stash_service(&repo);
+        let result = service.push(Some("With untracked"), true).await;
+
+        assert!(result.is_ok());
+
+        // Should have stashed the untracked file
+        assert!(!repo.path().join("untracked.txt").exists());
+    });
+}
+
+#[test]
+#[serial]
+fn stash_push_without_untracked() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        repo.create_file("untracked.txt", "untracked content");
+
+        let service = setup_stash_service(&repo);
+        let result = service.push(Some("Without untracked"), false).await;
+
+        // Should succeed but say no changes to save (tracked files are clean)
+        assert!(result.is_ok());
+
+        // Untracked file should still exist
+        assert!(repo.path().join("untracked.txt").exists());
+    });
+}
+
+#[test]
+#[serial]
+fn stash_push_no_changes() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+
+        let service = setup_stash_service(&repo);
+        let result = service.push(Some("No changes"), false).await;
+
+        assert!(result.is_ok());
+        assert!(result.unwrap().contains("No local changes"));
+    });
+}
+
+#[test]
+#[serial]
+fn stash_push_staged_changes() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        repo.create_file("staged.txt", "content");
+        repo.add("staged.txt");
+
+        let service = setup_stash_service(&repo);
+        let result = service.push(Some("Staged"), false).await;
+
+        assert!(result.is_ok());
+        assert!(!repo.has_changes());
+    });
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// STASH POP TESTS
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[serial]
+fn stash_pop_latest() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        repo.create_file("changes.txt", "content");
+        repo.stash_push(Some("To pop"));
+
+        assert!(!repo.has_changes());
+
+        let service = setup_stash_service(&repo);
+        let result = service.pop(None).await;
+
+        assert!(result.is_ok());
+
+        // Changes should be restored
+        assert!(repo.has_changes());
+        assert!(repo.path().join("changes.txt").exists());
+
+        // Stash list should be empty
+        let stashes = service.list().await.unwrap();
+        assert!(stashes.is_empty());
+    });
+}
+
+#[test]
+#[serial]
+fn stash_pop_specific() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+
+        // Create first stash
+        repo.create_file("first.txt", "first");
+        repo.stash_push(Some("First"));
+
+        // Create second stash
+        repo.create_file("second.txt", "second");
+        repo.stash_push(Some("Second"));
+
+        let service = setup_stash_service(&repo);
+
+        // Pop the older stash (index 1)
+        let result = service.pop(Some("stash@{1}")).await;
+
+        assert!(result.is_ok());
+        assert!(repo.path().join("first.txt").exists());
+
+        // Should have one stash left
+        let stashes = service.list().await.unwrap();
+        assert_eq!(stashes.len(), 1);
+    });
+}
+
+#[test]
+#[serial]
+fn stash_pop_empty_stack() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+
+        let service = setup_stash_service(&repo);
+        let result = service.pop(None).await;
+
+        // Should fail - no stash to pop
+        assert!(result.is_err());
+    });
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// STASH APPLY TESTS
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[serial]
+fn stash_apply_keeps_stash() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        repo.create_file("changes.txt", "content");
+        repo.stash_push(Some("To apply"));
+
+        let service = setup_stash_service(&repo);
+        let result = service.apply(None).await;
+
+        assert!(result.is_ok());
+
+        // Changes should be restored
+        assert!(repo.has_changes());
+
+        // Stash should still exist (unlike pop)
+        let stashes = service.list().await.unwrap();
+        assert_eq!(stashes.len(), 1);
+    });
+}
+
+#[test]
+#[serial]
+fn stash_apply_specific() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+
+        repo.create_file("first.txt", "first");
+        repo.stash_push(Some("First"));
+
+        repo.create_file("second.txt", "second");
+        repo.stash_push(Some("Second"));
+
+        let service = setup_stash_service(&repo);
+        let result = service.apply(Some("stash@{1}")).await;
+
+        assert!(result.is_ok());
+        assert!(repo.path().join("first.txt").exists());
+
+        // Both stashes should still exist
+        let stashes = service.list().await.unwrap();
+        assert_eq!(stashes.len(), 2);
+    });
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// STASH DROP TESTS
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[serial]
+fn stash_drop_latest() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        repo.create_file("changes.txt", "content");
+        repo.stash_push(Some("To drop"));
+
+        let service = setup_stash_service(&repo);
+        let result = service.drop("stash@{0}").await;
+
+        assert!(result.is_ok());
+
+        // Stash should be gone
+        let stashes = service.list().await.unwrap();
+        assert!(stashes.is_empty());
+
+        // Changes should NOT be restored
+        assert!(!repo.has_changes());
+    });
+}
+
+#[test]
+#[serial]
+fn stash_drop_specific() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+
+        repo.create_file("first.txt", "first");
+        repo.stash_push(Some("First"));
+
+        repo.create_file("second.txt", "second");
+        repo.stash_push(Some("Second"));
+
+        let service = setup_stash_service(&repo);
+        let result = service.drop("stash@{0}").await;
+
+        assert!(result.is_ok());
+
+        // Should have one stash left (the first one)
+        let stashes = service.list().await.unwrap();
+        assert_eq!(stashes.len(), 1);
+        assert!(stashes[0].message.contains("First"));
+    });
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// STASH CLEAR TESTS
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[serial]
+fn stash_clear_all() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+
+        // Create multiple stashes
+        for i in 1..=3 {
+            repo.create_file(&format!("file{}.txt", i), "content");
+            repo.stash_push(Some(&format!("Stash {}", i)));
+        }
+
+        let service = setup_stash_service(&repo);
+
+        // Verify we have stashes
+        let before = service.list().await.unwrap();
+        assert_eq!(before.len(), 3);
+
+        // Clear all
+        let result = service.clear().await;
+        assert!(result.is_ok());
+
+        // Should be empty
+        let after = service.list().await.unwrap();
+        assert!(after.is_empty());
+    });
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// STASH SHOW/QUICK_STAT TESTS
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[serial]
+fn stash_quick_stat() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        // Create a staged new file so stash show includes it in stats
+        repo.create_file("new_file.txt", "line1\nline2\nline3");
+        repo.add("new_file.txt");
+        repo.stash_push(Some("With stats"));
+
+        let service = setup_stash_service(&repo);
+        let stat = service.quick_stat("stash@{0}").await.unwrap();
+
+        assert_eq!(stat.reference, "stash@{0}");
+        // New staged files should show in stash stats
+        assert!(stat.files_changed >= 1);
+    });
+}
+
+#[test]
+#[serial]
+fn stash_show_full() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        // Create a staged new file
+        repo.create_file("new_file.txt", "content");
+        repo.add("new_file.txt");
+        repo.stash_push(Some("Full show"));
+
+        let service = setup_stash_service(&repo);
+        let show = service.show("stash@{0}").await.unwrap();
+
+        assert_eq!(show.reference, "stash@{0}");
+        assert!(!show.files.is_empty());
+    });
+}
+
+#[test]
+#[serial]
+fn stash_quick_stat_invalid_ref() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+
+        let service = setup_stash_service(&repo);
+        let result = service.quick_stat("invalid-ref").await;
+
+        assert!(result.is_err());
+    });
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// GITRU STASH TESTS (Branch-aware stashing)
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[serial]
+fn push_gitru_stash() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        // Create staged change so stash has content
+        repo.create_file("changes.txt", "content");
+        repo.add("changes.txt");
+
+        let service = setup_stash_service(&repo);
+        let result = service
+            .push_gitru_stash("main", "feature/target", false)
+            .await;
+
+        assert!(result.is_ok());
+
+        // Should have created a stash with gitru marker
+        let stashes = service.list().await.unwrap();
+        assert_eq!(stashes.len(), 1);
+        assert!(stashes[0].is_gitru);
+    });
+}
+
+#[test]
+#[serial]
+fn find_gitru_stash_for_branch() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        // Create staged change
+        repo.create_file("changes.txt", "content");
+        repo.add("changes.txt");
+
+        let service = setup_stash_service(&repo);
+
+        // Create a gitru stash: from "main" to "feature/target"
+        service
+            .push_gitru_stash("main", "feature/target", false)
+            .await
+            .unwrap();
+
+        // find_gitru_stash_for_branch matches against from_branch
+        // So we look for stashes created FROM "main"
+        let found = service.find_gitru_stash_for_branch("main").await.unwrap();
+
+        assert!(found.is_some());
+        let branch_stash = found.unwrap();
+        assert_eq!(branch_stash.from_branch, "main");
+        assert_eq!(branch_stash.to_branch, "feature/target");
+    });
+}
+
+#[test]
+#[serial]
+fn find_gitru_stash_not_found() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+
+        let service = setup_stash_service(&repo);
+
+        // No stash exists
+        let found = service
+            .find_gitru_stash_for_branch("nonexistent")
+            .await
+            .unwrap();
+
+        assert!(found.is_none());
+    });
+}
+
+#[test]
+#[serial]
+fn pop_gitru_stash_for_branch() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        // Create staged change
+        repo.create_file("changes.txt", "content to stash");
+        repo.add("changes.txt");
+
+        let service = setup_stash_service(&repo);
+
+        // Create a gitru stash: from "main" to "feature/target"
+        service
+            .push_gitru_stash("main", "feature/target", false)
+            .await
+            .unwrap();
+        assert!(!repo.has_changes());
+
+        // Pop it - find by from_branch
+        let result = service.pop_gitru_stash_for_branch("main").await;
+
+        assert!(result.is_ok());
+        assert!(repo.has_changes());
+
+        // Stash should be gone
+        let stashes = service.list().await.unwrap();
+        assert!(stashes.is_empty());
+    });
+}

--- a/crates/ipc/src/commands.rs
+++ b/crates/ipc/src/commands.rs
@@ -31,19 +31,18 @@ pub async fn add_local_git_repo(repo_path: String) -> Result<Option<RepoSitorySt
     let path = Path::new(&repo_path);
 
     if !path.exists() {
-        return Err(format!("Path does not exist: {}", repo_path));
+        return Err(format!("Path does not exist: {repo_path}"));
     }
 
     if !path.is_dir() {
-        return Err(format!("Path is not a directory: {}", repo_path));
+        return Err(format!("Path is not a directory: {repo_path}"));
     }
 
     let git_dir = path.join(".git");
 
     if !git_dir.exists() || !git_dir.is_dir() {
         return Err(format!(
-            "Not a valid Git repository (no .git folder): {}",
-            repo_path
+            "Not a valid Git repository (no .git folder): {repo_path}"
         ));
     }
 
@@ -141,7 +140,7 @@ pub async fn select_repository(
     let manager_guard = manager.lock().map_err(|e| e.to_string())?;
     let store = manager_guard
         .get_store()
-        .map_err(|e| format!("Failed to get store: {}", e))?;
+        .map_err(|e| format!("Failed to get store: {e}"))?;
 
     store.set(SELECTED_REPO_KEY, repo_id);
     store.save().map_err(|e| e.to_string())?;
@@ -193,8 +192,7 @@ impl ExternalOpener {
             "terminal" => Ok(Self::Terminal),
             "ghostty" | "ghosty" => Ok(Self::Ghostty),
             other => Err(format!(
-                "Unsupported opener '{}'. Use one of: vscode, cursor, finder, terminal, ghostty",
-                other
+                "Unsupported opener '{other}'. Use one of: vscode, cursor, finder, terminal, ghostty"
             )),
         }
     }
@@ -223,7 +221,7 @@ fn open_on_macos(opener: ExternalOpener, file_path: &str, line: Option<u32>) -> 
                 command
                     .arg("--args")
                     .arg("--goto")
-                    .arg(format!("{}:{}", file_path, line));
+                    .arg(format!("{file_path}:{line}"));
             } else {
                 command.arg(file_path);
             }
@@ -234,7 +232,7 @@ fn open_on_macos(opener: ExternalOpener, file_path: &str, line: Option<u32>) -> 
                 command
                     .arg("--args")
                     .arg("--goto")
-                    .arg(format!("{}:{}", file_path, line));
+                    .arg(format!("{file_path}:{line}"));
             } else {
                 command.arg(file_path);
             }
@@ -258,7 +256,7 @@ fn open_on_macos(opener: ExternalOpener, file_path: &str, line: Option<u32>) -> 
 
     command
         .spawn()
-        .map_err(|e| format!("Failed to launch opener on macOS: {}", e))?;
+        .map_err(|e| format!("Failed to launch opener on macOS: {e}"))?;
 
     Ok(())
 }

--- a/crates/ipc/src/repo_manager.rs
+++ b/crates/ipc/src/repo_manager.rs
@@ -88,11 +88,11 @@ impl RepoManager {
         for (index, repo) in repos.iter().enumerate() {
             let age = current_time.saturating_sub(repo.last_updated);
 
-            if age > stale_threshold {
-                if let Ok(refreshed) = self.refresh_repository_info_internal(repo).await {
-                    updated_repos[index] = refreshed;
-                    needs_save = true;
-                }
+            if age > stale_threshold
+                && let Ok(refreshed) = self.refresh_repository_info_internal(repo).await
+            {
+                updated_repos[index] = refreshed;
+                needs_save = true;
             }
         }
 

--- a/crates/ipc/src/repo_manager.rs
+++ b/crates/ipc/src/repo_manager.rs
@@ -49,7 +49,7 @@ impl RepoManager {
     pub fn get_store(&self) -> Result<Arc<tauri_plugin_store::Store<tauri::Wry>>, String> {
         self.app
             .store(STORE_FILE)
-            .map_err(|e| format!("Failed to get store: {}", e))
+            .map_err(|e| format!("Failed to get store: {e}"))
     }
 
     fn get_current_timestamp() -> u64 {
@@ -208,7 +208,7 @@ impl RepoManager {
         let repo = repos
             .iter()
             .find(|r| r.id == repo_id)
-            .ok_or_else(|| format!("Repository not found: {}", repo_id))?;
+            .ok_or_else(|| format!("Repository not found: {repo_id}"))?;
 
         let updated_repo = self.refresh_repository_info_internal(repo).await?;
 


### PR DESCRIPTION
- Implement integration tests for commit, branch, status, history, and stash parsers using real git repositories.
- Create a new test suite for StashService, covering functionalities like stash push, pop, apply, drop, and listing stashes.
- Ensure tests validate expected behaviors for various scenarios, including handling of untracked files and branch-aware stashing.