### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,9 @@ name: test
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/ruru-m07/gitru/security/code-scanning/2](https://github.com/ruru-m07/gitru/security/code-scanning/2)

Add an explicit workflow-level `permissions` block with least privilege required by current steps.  
Best fix here is at the root of `.github/workflows/test.yml` (applies to both `test` and `lint` jobs): set `contents: read`. This preserves existing behavior (checkout still works) while preventing unintended broader token scopes if repo/org defaults change.

Edit region: near the top of `.github/workflows/test.yml`, after `on:` block (or before `jobs:`), add:

```yml
permissions:
  contents: read
```

No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
