### PR TITLE
fix(desktop): correct sync toolbar actions

### DIFF
--- a/apps/desktop/src/features/git/components/main-action-bar.tsx
+++ b/apps/desktop/src/features/git/components/main-action-bar.tsx
@@ -107,7 +107,7 @@ export const MainActionBar = () => {
         <span className="text-xs text-muted-foreground font-normal">
           {isPending ? "Syncing…" : syncState.label}
         </span>
-        <span className="truncate block w-full text-left">
+        <span className="truncate block w-full text-left text-sm">
           {syncState.detail}
         </span>
       </div>

--- a/apps/desktop/src/features/git/components/main-action-bar.tsx
+++ b/apps/desktop/src/features/git/components/main-action-bar.tsx
@@ -1,38 +1,118 @@
 import { Button } from "@gitru/ui/components/button";
+import { useCommandNavigation } from "@gitru/ui/components/command";
+import {
+  Menu,
+  MenuItem,
+  MenuPopup,
+  MenuTrigger,
+} from "@gitru/ui/components/menu";
 import { Separator } from "@gitru/ui/components/separator";
 import {
+  ArrowDownToLine,
   ArrowUpFromLine,
   ChevronDown,
-  ChevronsUp,
   GitBranch,
   GitCommitVertical,
+  GitCompareArrows,
   Loader2,
 } from "lucide-react";
+import { toast } from "sonner";
 import {
   useGetCurrentBranch,
   useGetRepoOperation,
   useGetStatusAheadBehind,
+  useGitPublishBranch,
+  useGitPull,
   useGitPush,
 } from "@/hooks";
+import { resolveSyncState, type SyncAction } from "./sync-state";
+
+const successMessages: Record<SyncAction, string> = {
+  publish: "Branch published",
+  push: "Changes pushed",
+  pull: "Changes pulled",
+};
 
 export const MainActionBar = () => {
   const { data: currentBranch } = useGetCurrentBranch();
   const { data: statusAheadBehind } = useGetStatusAheadBehind();
   const { data: operation } = useGetRepoOperation();
+  const branchNavigation = useCommandNavigation();
 
-  const { mutateAsync: push, isPending } = useGitPush();
+  const publishMutation = useGitPublishBranch();
+  const pushMutation = useGitPush();
+  const pullMutation = useGitPull();
 
-  const detached = currentBranch?.is_detached ?? false;
+  const detached =
+    currentBranch?.is_detached ?? statusAheadBehind?.is_detached ?? false;
   const rebasing = operation?.isRebasing ?? false;
   // While rebasing HEAD is detached, so the rebased branch name lives on the operation.
   const rebaseBranch = operation?.headName?.replace(/^refs\/heads\//, "");
+  const syncState = resolveSyncState({
+    isDetached: detached,
+    operationKind: operation?.kind,
+    status: statusAheadBehind
+      ? {
+          ahead: statusAheadBehind.ahead,
+          behind: statusAheadBehind.behind,
+          isPublished: statusAheadBehind.is_published,
+          isDetached: statusAheadBehind.is_detached,
+          localBranch: statusAheadBehind.local_branch,
+          upstreamBranch: statusAheadBehind.upstream_branch,
+        }
+      : undefined,
+  });
+  const isPending =
+    publishMutation.isPending ||
+    pushMutation.isPending ||
+    pullMutation.isPending;
+
+  const runSyncAction = async (action: SyncAction) => {
+    try {
+      if (action === "publish") await publishMutation.mutateAsync();
+      if (action === "push") await pushMutation.mutateAsync();
+      if (action === "pull") await pullMutation.mutateAsync();
+      toast.success(successMessages[action]);
+    } catch {
+      // Mutation hooks surface the command's actionable error message.
+    }
+  };
+
+  const syncIcon = isPending ? (
+    <Loader2 className="animate-spin size-7.5" strokeWidth={1.5} />
+  ) : syncState.kind === "behind" ? (
+    <ArrowDownToLine className="size-7.5" strokeWidth={1.5} />
+  ) : syncState.kind === "diverged" ? (
+    <GitCompareArrows className="size-7.5" strokeWidth={1.5} />
+  ) : (
+    <ArrowUpFromLine className="size-7.5" strokeWidth={1.5} />
+  );
+
+  const syncContent = (
+    <div className="flex items-center gap-4 min-w-0 flex-1">
+      {syncIcon}
+      <div className="flex flex-col flex-1 items-start min-w-0">
+        <span className="text-xs text-muted-foreground font-normal">
+          {isPending ? "Syncing…" : syncState.label}
+        </span>
+        <span className="truncate block w-full text-left">
+          {syncState.detail}
+        </span>
+      </div>
+    </div>
+  );
 
   return (
     <div className="w-full justify-between min-h-14 max-h-14 h-14 border-b flex">
       <div className="min-h-14 max-h-14 h-14 flex w-full">
         <Button
+          aria-label="Switch branch"
           className="flex justify-between items-center min-h-full rounded-none border-x-0 max-w-72 w-full"
           variant="ghost"
+          onClick={() => {
+            branchNavigation.setOpen(true);
+            branchNavigation.push("branch-list");
+          }}
         >
           <div className="flex items-center gap-4 min-w-0 flex-1">
             {detached ? (
@@ -57,89 +137,72 @@ export const MainActionBar = () => {
             </div>
           </div>
 
-          <ChevronDown size={18} />
+          <ChevronDown aria-hidden="true" size={18} />
         </Button>
-        <Separator orientation="vertical" className={"border-0"} />
-        {detached ? null : statusAheadBehind &&
-          statusAheadBehind.is_published ? (
-          (statusAheadBehind && statusAheadBehind.ahead > 0) ||
-          (statusAheadBehind && statusAheadBehind.behind > 0) ? (
-            <>
-              <Button
-                className="flex justify-between items-center min-h-full rounded-none border-x-0 w-72"
-                variant={"ghost"}
-                onClick={async () => {
-                  await push();
-                }}
+        <Separator orientation="vertical" className="border-0" />
+
+        {syncState.kind === "detached" ? null : syncState.kind ===
+          "diverged" ? (
+          <>
+            <Menu>
+              <MenuTrigger
+                render={
+                  <Button
+                    aria-label={`${syncState.label}. Choose pull or push.`}
+                    className="flex justify-between items-center min-h-full rounded-none border-x-0 w-72"
+                    variant="ghost"
+                    disabled={isPending}
+                  />
+                }
               >
-                <div className="flex items-center justify-center gap-4">
-                  {isPending ? (
-                    <Loader2
-                      className="animate-spin size-7.5"
-                      strokeWidth={1.5}
-                    />
-                  ) : (
-                    <ChevronsUp className="size-8 rotate-180" />
-                  )}
-                  <div className="flex-col flex items-start">
-                    <span className="text-xs text-muted-foreground font-[450]">
-                      {statusAheadBehind.ahead > 0
-                        ? "Push to Origin"
-                        : "Pull from Origin"}
-                    </span>
-                    <span>
-                      {statusAheadBehind
-                        ? `${statusAheadBehind.ahead} / ${statusAheadBehind.behind}`
-                        : "0 / 0"}
-                    </span>
-                  </div>
-                </div>
-                <ChevronDown size={18} />
-              </Button>
-              <Separator orientation="vertical" className={"border-0"} />
-            </>
-          ) : null
-        ) : (
+                {syncContent}
+                <ChevronDown aria-hidden="true" size={18} />
+              </MenuTrigger>
+              <MenuPopup align="end" className="w-64">
+                <MenuItem
+                  closeOnClick
+                  onClick={() => void runSyncAction("pull")}
+                >
+                  <ArrowDownToLine />
+                  Pull remote changes
+                </MenuItem>
+                <MenuItem
+                  closeOnClick
+                  onClick={() => void runSyncAction("push")}
+                >
+                  <ArrowUpFromLine />
+                  Push local commits
+                </MenuItem>
+              </MenuPopup>
+            </Menu>
+            <Separator orientation="vertical" className="border-0" />
+          </>
+        ) : syncState.primaryAction ? (
           <>
             <Button
-              className="flex border-x-0 justify-between items-center min-h-full rounded-none max-w-60 w-60"
-              variant={"ghost"}
-              onClick={async () => {
-                await push();
-              }}
+              aria-label={syncState.label}
+              className="flex border-x-0 justify-between items-center min-h-full rounded-none max-w-72 w-72"
+              variant="ghost"
+              disabled={isPending}
+              onClick={() => void runSyncAction(syncState.primaryAction!)}
             >
-              <div className="flex items-center gap-4 min-w-0 flex-1">
-                {isPending ? (
-                  <Loader2
-                    className="animate-spin size-7.5"
-                    strokeWidth={1.5}
-                  />
-                ) : (
-                  <ArrowUpFromLine className="size-7.5" strokeWidth={1.5} />
-                )}
-                <div className="flex flex-col flex-1 items-start min-w-0">
-                  <span className="text-xs text-muted-foreground font-normal">
-                    Publish Branch
-                  </span>
-                  <span className="truncate block w-full text-left">
-                    Published as {currentBranch?.name}
-                  </span>
-                </div>
-              </div>
+              {syncContent}
             </Button>
-            <Separator orientation="vertical" className={"border-0"} />
-            <Button
-              className="flex border-x-0 justify-between items-center min-h-full rounded-none"
-              variant={"ghost"}
-              onClick={async () => {}}
+            <Separator orientation="vertical" className="border-0" />
+          </>
+        ) : (
+          <>
+            <div
+              aria-live="polite"
+              className="flex border-x-0 items-center min-h-full max-w-72 w-72 px-4"
+              role="status"
             >
-              <ChevronDown size={18} />
-            </Button>
-            <Separator orientation="vertical" className={"border-0"} />
+              {syncContent}
+            </div>
+            <Separator orientation="vertical" className="border-0" />
           </>
         )}
       </div>
-      <div></div>
     </div>
   );
 };

--- a/apps/desktop/src/features/git/components/main-action-bar.tsx
+++ b/apps/desktop/src/features/git/components/main-action-bar.tsx
@@ -15,22 +15,29 @@ import {
   GitCommitVertical,
   GitCompareArrows,
   Loader2,
+  RefreshCw,
 } from "lucide-react";
 import { toast } from "sonner";
 import {
   useGetCurrentBranch,
   useGetRepoOperation,
   useGetStatusAheadBehind,
+  useGitFetch,
   useGitPublishBranch,
   useGitPull,
   useGitPush,
 } from "@/hooks";
-import { resolveSyncState, type SyncAction } from "./sync-state";
+import {
+  isSyncControlVisible,
+  resolveSyncState,
+  type SyncAction,
+} from "./sync-state";
 
 const successMessages: Record<SyncAction, string> = {
   publish: "Branch published",
   push: "Changes pushed",
   pull: "Changes pulled",
+  fetch: "Remote changes fetched",
 };
 
 export const MainActionBar = () => {
@@ -42,6 +49,7 @@ export const MainActionBar = () => {
   const publishMutation = useGitPublishBranch();
   const pushMutation = useGitPush();
   const pullMutation = useGitPull();
+  const fetchMutation = useGitFetch();
 
   const detached =
     currentBranch?.is_detached ?? statusAheadBehind?.is_detached ?? false;
@@ -65,13 +73,15 @@ export const MainActionBar = () => {
   const isPending =
     publishMutation.isPending ||
     pushMutation.isPending ||
-    pullMutation.isPending;
+    pullMutation.isPending ||
+    fetchMutation.isPending;
 
   const runSyncAction = async (action: SyncAction) => {
     try {
       if (action === "publish") await publishMutation.mutateAsync();
       if (action === "push") await pushMutation.mutateAsync();
       if (action === "pull") await pullMutation.mutateAsync();
+      if (action === "fetch") await fetchMutation.mutateAsync();
       toast.success(successMessages[action]);
     } catch {
       // Mutation hooks surface the command's actionable error message.
@@ -84,6 +94,8 @@ export const MainActionBar = () => {
     <ArrowDownToLine className="size-7.5" strokeWidth={1.5} />
   ) : syncState.kind === "diverged" ? (
     <GitCompareArrows className="size-7.5" strokeWidth={1.5} />
+  ) : syncState.kind === "synced" ? (
+    <RefreshCw className="size-7.5" strokeWidth={1.5} />
   ) : (
     <ArrowUpFromLine className="size-7.5" strokeWidth={1.5} />
   );
@@ -141,7 +153,7 @@ export const MainActionBar = () => {
         </Button>
         <Separator orientation="vertical" className="border-0" />
 
-        {syncState.kind === "detached" ? null : syncState.kind ===
+        {!isSyncControlVisible(syncState) ? null : syncState.kind ===
           "diverged" ? (
           <>
             <Menu>

--- a/apps/desktop/src/features/git/components/sync-state.ts
+++ b/apps/desktop/src/features/git/components/sync-state.ts
@@ -1,4 +1,4 @@
-export type SyncAction = "publish" | "push" | "pull";
+export type SyncAction = "publish" | "push" | "pull" | "fetch";
 
 export type SyncStateKind =
   | "loading"
@@ -16,6 +16,9 @@ export interface SyncState {
   detail: string;
   primaryAction: SyncAction | null;
 }
+
+export const isSyncControlVisible = (state: SyncState) =>
+  state.kind !== "loading" && state.kind !== "detached";
 
 interface SyncStatus {
   ahead: number;
@@ -114,8 +117,8 @@ export function resolveSyncState({
 
   return {
     kind: "synced",
-    label: "Up to Date",
-    detail: status.upstreamBranch ?? "Remote branch is synced",
-    primaryAction: null,
+    label: "Fetch",
+    detail: status.upstreamBranch ?? "Check for remote changes",
+    primaryAction: "fetch",
   };
 }

--- a/apps/desktop/src/features/git/components/sync-state.ts
+++ b/apps/desktop/src/features/git/components/sync-state.ts
@@ -1,0 +1,121 @@
+export type SyncAction = "publish" | "push" | "pull";
+
+export type SyncStateKind =
+  | "loading"
+  | "detached"
+  | "inProgress"
+  | "unpublished"
+  | "ahead"
+  | "behind"
+  | "diverged"
+  | "synced";
+
+export interface SyncState {
+  kind: SyncStateKind;
+  label: string;
+  detail: string;
+  primaryAction: SyncAction | null;
+}
+
+interface SyncStatus {
+  ahead: number;
+  behind: number;
+  isPublished: boolean;
+  isDetached: boolean;
+  localBranch?: string;
+  upstreamBranch?: string;
+}
+
+interface ResolveSyncStateInput {
+  status?: SyncStatus;
+  operationKind?: string;
+  isDetached?: boolean;
+}
+
+const operationLabels: Record<string, string> = {
+  merge: "Merge in progress",
+  revert: "Revert in progress",
+  cherryPick: "Cherry-pick in progress",
+  bisect: "Bisect in progress",
+  rebase: "Rebase in progress",
+  rebaseInteractive: "Rebase in progress",
+  rebaseMerge: "Rebase in progress",
+  applyMailbox: "Patch apply in progress",
+  other: "Git operation in progress",
+};
+
+export function resolveSyncState({
+  status,
+  operationKind,
+  isDetached,
+}: ResolveSyncStateInput): SyncState {
+  if (operationKind && operationKind !== "clean") {
+    return {
+      kind: "inProgress",
+      label: operationLabels[operationKind] ?? "Git operation in progress",
+      detail: "Finish or abort it before syncing",
+      primaryAction: null,
+    };
+  }
+
+  if (isDetached || status?.isDetached) {
+    return {
+      kind: "detached",
+      label: "Detached HEAD",
+      detail: "Checkout a branch to sync",
+      primaryAction: null,
+    };
+  }
+
+  if (!status) {
+    return {
+      kind: "loading",
+      label: "Checking remote status",
+      detail: "Please wait…",
+      primaryAction: null,
+    };
+  }
+
+  if (!status.isPublished) {
+    return {
+      kind: "unpublished",
+      label: "Publish Branch",
+      detail: status.localBranch ?? "Set an upstream branch",
+      primaryAction: "publish",
+    };
+  }
+
+  if (status.ahead > 0 && status.behind > 0) {
+    return {
+      kind: "diverged",
+      label: "Branches Diverged",
+      detail: `↑${status.ahead} ↓${status.behind}`,
+      primaryAction: null,
+    };
+  }
+
+  if (status.ahead > 0) {
+    return {
+      kind: "ahead",
+      label: "Push to Origin",
+      detail: `${status.ahead} commit${status.ahead === 1 ? "" : "s"} ahead`,
+      primaryAction: "push",
+    };
+  }
+
+  if (status.behind > 0) {
+    return {
+      kind: "behind",
+      label: "Pull from Origin",
+      detail: `${status.behind} commit${status.behind === 1 ? "" : "s"} behind`,
+      primaryAction: "pull",
+    };
+  }
+
+  return {
+    kind: "synced",
+    label: "Up to Date",
+    detail: status.upstreamBranch ?? "Remote branch is synced",
+    primaryAction: null,
+  };
+}

--- a/apps/desktop/tests/sync-state.test.ts
+++ b/apps/desktop/tests/sync-state.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { resolveSyncState } from "../src/features/git/components/sync-state";
+import {
+  isSyncControlVisible,
+  resolveSyncState,
+} from "../src/features/git/components/sync-state";
 
 const published = {
   ahead: 0,
@@ -12,10 +15,12 @@ const published = {
 
 describe("resolveSyncState", () => {
   test("models the loading state", () => {
-    expect(resolveSyncState({})).toMatchObject({
+    const state = resolveSyncState({});
+    expect(state).toMatchObject({
       kind: "loading",
       primaryAction: null,
     });
+    expect(isSyncControlVisible(state)).toBe(false);
   });
 
   test("models an unpublished branch as publish", () => {
@@ -44,11 +49,14 @@ describe("resolveSyncState", () => {
     ).toMatchObject({ kind: "diverged", primaryAction: null });
   });
 
-  test("models a synced branch without an action", () => {
-    expect(resolveSyncState({ status: published })).toMatchObject({
+  test("models a synced branch as fetch", () => {
+    const state = resolveSyncState({ status: published });
+    expect(state).toMatchObject({
       kind: "synced",
-      primaryAction: null,
+      label: "Fetch",
+      primaryAction: "fetch",
     });
+    expect(isSyncControlVisible(state)).toBe(true);
   });
 
   test("models detached HEAD without a publish action", () => {

--- a/apps/desktop/tests/sync-state.test.ts
+++ b/apps/desktop/tests/sync-state.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { resolveSyncState } from "../src/features/git/components/sync-state";
+
+const published = {
+  ahead: 0,
+  behind: 0,
+  isPublished: true,
+  isDetached: false,
+  localBranch: "main",
+  upstreamBranch: "origin/main",
+};
+
+describe("resolveSyncState", () => {
+  test("models the loading state", () => {
+    expect(resolveSyncState({})).toMatchObject({
+      kind: "loading",
+      primaryAction: null,
+    });
+  });
+
+  test("models an unpublished branch as publish", () => {
+    expect(
+      resolveSyncState({ status: { ...published, isPublished: false } }),
+    ).toMatchObject({ kind: "unpublished", primaryAction: "publish" });
+  });
+
+  test("models an ahead branch as push", () => {
+    expect(
+      resolveSyncState({ status: { ...published, ahead: 2 } }),
+    ).toMatchObject({ kind: "ahead", primaryAction: "push" });
+  });
+
+  test("models a behind branch as pull", () => {
+    expect(
+      resolveSyncState({ status: { ...published, behind: 3 } }),
+    ).toMatchObject({ kind: "behind", primaryAction: "pull" });
+  });
+
+  test("does not guess a primary action for diverged branches", () => {
+    expect(
+      resolveSyncState({
+        status: { ...published, ahead: 2, behind: 3 },
+      }),
+    ).toMatchObject({ kind: "diverged", primaryAction: null });
+  });
+
+  test("models a synced branch without an action", () => {
+    expect(resolveSyncState({ status: published })).toMatchObject({
+      kind: "synced",
+      primaryAction: null,
+    });
+  });
+
+  test("models detached HEAD without a publish action", () => {
+    expect(resolveSyncState({ isDetached: true })).toMatchObject({
+      kind: "detached",
+      primaryAction: null,
+    });
+  });
+
+  test("blocks syncing while any git operation is in progress", () => {
+    expect(
+      resolveSyncState({ status: published, operationKind: "merge" }),
+    ).toMatchObject({ kind: "inProgress", primaryAction: null });
+  });
+});

--- a/crates/git/service/branch.rs
+++ b/crates/git/service/branch.rs
@@ -317,7 +317,7 @@ impl BranchService {
         self.ctx
             .runner
             .run_with_options(
-                &["push", "-u", "origin", format!("@{}", branch.name).as_str()],
+                &["push", "-u", "origin", branch.name.as_str()],
                 GitRunOptions::default_read().with_timeout(Duration::from_secs(60)),
             )
             .await?;

--- a/crates/git/tests/branch_service.rs
+++ b/crates/git/tests/branch_service.rs
@@ -87,6 +87,30 @@ fn ahead_behind_when_detached() {
     });
 }
 
+#[test]
+#[serial]
+fn publish_branch_pushes_current_branch_and_sets_upstream() {
+    run_async(async {
+        let repo = TestRepo::new();
+        repo.commit_file("README.md", "# Test", "Initial commit");
+        let _remote = repo.setup_remote();
+        repo.create_branch("feature/publish-me");
+
+        let service = setup_branch_service(&repo);
+        let message = service.publish_branch().await.unwrap();
+
+        assert_eq!(message, "Published `feature/publish-me` to origin");
+        assert_eq!(
+            repo.git(&["rev-parse", "--abbrev-ref", "@{upstream}"]),
+            "origin/feature/publish-me"
+        );
+        assert_eq!(
+            repo.git(&["rev-parse", "HEAD"]),
+            repo.git(&["rev-parse", "refs/remotes/origin/feature/publish-me"])
+        );
+    });
+}
+
 // ══════════════════════════════════════════════════════════════════════════════
 // LIST BRANCHES TESTS
 // ══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- model loading, unpublished, ahead, behind, diverged, synced, detached, and in-progress sync states
- dispatch the matching publish, pull, or push command
- require an explicit pull or push choice for diverged branches
- connect the branch selector to the existing branch panel
- fix the publish refspec and add bare-remote integration coverage

## Validation

- bun test apps/desktop/tests/sync-state.test.ts
- bun run --cwd apps/desktop build
- cargo test -p git --test branch_service
- cargo fmt --all -- --check
- focused Biome and git diff checks

Linear: https://linear.app/catra/issue/RURU-55/fix-sync-toolbar-pull-push-and-publish-behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added unified Git synchronization status in the desktop app, covering publishing, pushing, pulling, diverged branches, detached states, and ongoing operations.
  - Added pull and publish actions alongside push, with success notifications.
  - Added a pull/push menu for branches that have diverged.
  - Branch controls now open command navigation options.

- **Bug Fixes**
  - Fixed branch publishing so the correct branch is pushed and configured for upstream tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->