### PR TITLE
perf(desktop): prioritize persistent tab activation

### DIFF
--- a/apps/desktop/src-tauri/src/app_menu.rs
+++ b/apps/desktop/src-tauri/src/app_menu.rs
@@ -1,0 +1,149 @@
+use tauri::{
+    menu::{
+        AboutMetadata, Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu, HELP_SUBMENU_ID,
+        WINDOW_SUBMENU_ID,
+    },
+    AppHandle, Emitter, EventTarget, Manager,
+};
+
+const MAIN_WEBVIEW_LABEL: &str = "main";
+const TAB_SHORTCUT_EVENT: &str = "gitru:tab-switch-shortcut";
+
+const NEW_TAB_MENU_ID: &str = "gitru.new-tab";
+const CLOSE_TAB_MENU_ID: &str = "gitru.close-tab";
+const CLOSE_WINDOW_MENU_ID: &str = "gitru.close-window";
+
+pub fn build(app_handle: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
+    let package_info = app_handle.package_info();
+    let config = app_handle.config();
+    let about_metadata = AboutMetadata {
+        name: Some(package_info.name.clone()),
+        version: Some(package_info.version.to_string()),
+        copyright: config.bundle.copyright.clone(),
+        authors: config
+            .bundle
+            .publisher
+            .clone()
+            .map(|publisher| vec![publisher]),
+        ..Default::default()
+    };
+
+    let app_menu = Submenu::with_items(
+        app_handle,
+        package_info.name.clone(),
+        true,
+        &[
+            &PredefinedMenuItem::about(app_handle, None, Some(about_metadata))?,
+            &PredefinedMenuItem::separator(app_handle)?,
+            &PredefinedMenuItem::services(app_handle, None)?,
+            &PredefinedMenuItem::separator(app_handle)?,
+            &PredefinedMenuItem::hide(app_handle, None)?,
+            &PredefinedMenuItem::hide_others(app_handle, None)?,
+            &PredefinedMenuItem::separator(app_handle)?,
+            &PredefinedMenuItem::quit(app_handle, None)?,
+        ],
+    )?;
+
+    let file_menu = Submenu::with_items(
+        app_handle,
+        "File",
+        true,
+        &[
+            &MenuItem::with_id(
+                app_handle,
+                NEW_TAB_MENU_ID,
+                "New Tab",
+                true,
+                Some("CmdOrCtrl+T"),
+            )?,
+            &MenuItem::with_id(
+                app_handle,
+                CLOSE_TAB_MENU_ID,
+                "Close Tab",
+                true,
+                Some("CmdOrCtrl+W"),
+            )?,
+            &PredefinedMenuItem::separator(app_handle)?,
+            &MenuItem::with_id(
+                app_handle,
+                CLOSE_WINDOW_MENU_ID,
+                "Close Window",
+                true,
+                Some("CmdOrCtrl+Shift+W"),
+            )?,
+        ],
+    )?;
+
+    let edit_menu = Submenu::with_items(
+        app_handle,
+        "Edit",
+        true,
+        &[
+            &PredefinedMenuItem::undo(app_handle, None)?,
+            &PredefinedMenuItem::redo(app_handle, None)?,
+            &PredefinedMenuItem::separator(app_handle)?,
+            &PredefinedMenuItem::cut(app_handle, None)?,
+            &PredefinedMenuItem::copy(app_handle, None)?,
+            &PredefinedMenuItem::paste(app_handle, None)?,
+            &PredefinedMenuItem::select_all(app_handle, None)?,
+        ],
+    )?;
+
+    let view_menu = Submenu::with_items(
+        app_handle,
+        "View",
+        true,
+        &[&PredefinedMenuItem::fullscreen(app_handle, None)?],
+    )?;
+
+    // Keep the standard window controls, but omit Tauri's second native
+    // Close Window item so Cmd+W can belong exclusively to Close Tab.
+    let window_menu = Submenu::with_id_and_items(
+        app_handle,
+        WINDOW_SUBMENU_ID,
+        "Window",
+        true,
+        &[
+            &PredefinedMenuItem::minimize(app_handle, None)?,
+            &PredefinedMenuItem::maximize(app_handle, None)?,
+        ],
+    )?;
+
+    let help_menu = Submenu::with_id_and_items(app_handle, HELP_SUBMENU_ID, "Help", true, &[])?;
+
+    Menu::with_items(
+        app_handle,
+        &[
+            &app_menu,
+            &file_menu,
+            &edit_menu,
+            &view_menu,
+            &window_menu,
+            &help_menu,
+        ],
+    )
+}
+
+pub fn handle_event(app_handle: &AppHandle, event: MenuEvent) {
+    if event.id() == NEW_TAB_MENU_ID {
+        emit_tab_shortcut(app_handle, "create");
+    } else if event.id() == CLOSE_TAB_MENU_ID {
+        emit_tab_shortcut(app_handle, "close");
+    } else if event.id() == CLOSE_WINDOW_MENU_ID {
+        if let Some(window) = app_handle.get_webview_window(MAIN_WEBVIEW_LABEL) {
+            if let Err(error) = window.close() {
+                log::error!("failed to close main window: {error}");
+            }
+        }
+    }
+}
+
+fn emit_tab_shortcut(app_handle: &AppHandle, phase: &str) {
+    if let Err(error) = app_handle.emit_to(
+        EventTarget::webview(MAIN_WEBVIEW_LABEL),
+        TAB_SHORTCUT_EVENT,
+        serde_json::json!({ "phase": phase }),
+    ) {
+        log::error!("failed to emit {phase} tab shortcut: {error}");
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -11,11 +11,13 @@ use tauri::{App, Manager};
 use tauri_plugin_store::StoreExt;
 use tokio::sync::RwLock;
 
+#[cfg(target_os = "macos")]
+mod app_menu;
 mod commands;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tauri::Builder::default()
+    let builder = tauri::Builder::default()
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
@@ -31,7 +33,14 @@ pub fn run() {
         .manage(AppState {
             services: RwLock::new(HashMap::new()),
         })
-        .manage(Arc::new(SessionManager::new()))
+        .manage(Arc::new(SessionManager::new()));
+
+    #[cfg(target_os = "macos")]
+    let builder = builder
+        .menu(app_menu::build)
+        .on_menu_event(app_menu::handle_event);
+
+    builder
         .setup(|app| {
             setup_managers(app);
             Ok(())

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -37,6 +37,26 @@ html {
   app-region: drag;
 }
 
+.title-bar-no-drag {
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
+}
+
+.workspace-tab-shell {
+  container-type: inline-size;
+}
+
+@container (max-width: 96px) {
+  .workspace-tab-close[data-active="false"] {
+    display: none;
+  }
+
+  .workspace-tab:hover .workspace-tab-close[data-active="false"],
+  .workspace-tab:focus-within .workspace-tab-close[data-active="false"] {
+    display: inline-flex;
+  }
+}
+
 .custom-scroll {
   scrollbar-width: thin;
   scrollbar-color: var(--color-muted) transparent;

--- a/apps/desktop/src/bootstrap/app-root.tsx
+++ b/apps/desktop/src/bootstrap/app-root.tsx
@@ -10,6 +10,7 @@ import { WorkspaceSessionSnapshot } from "@/types/store";
 import { TabContextProvider } from "../context/tab-context-provider";
 import { colorKeyList } from "../lib/colors";
 import {
+  resolveTabManagementShortcut,
   TAB_SWITCH_SHORTCUT_EVENT,
   type TabSwitchShortcutPayload,
 } from "../lib/tab-switching";
@@ -119,6 +120,15 @@ const AppRouter = () => {
     };
 
     const handleKeyDown = (event: KeyboardEvent) => {
+      const managementShortcut = resolveTabManagementShortcut(event);
+
+      if (managementShortcut) {
+        event.preventDefault();
+        event.stopPropagation();
+        emitTabSwitchShortcut({ phase: managementShortcut });
+        return;
+      }
+
       if (!(event.ctrlKey || event.metaKey) || event.key !== "Tab") {
         return;
       }

--- a/apps/desktop/src/components/custom-title-bar/constants.ts
+++ b/apps/desktop/src/components/custom-title-bar/constants.ts
@@ -4,13 +4,18 @@ import {
 } from "@dnd-kit/modifiers";
 
 export const DEFAULT_TAB_ROUTE = "/app/git";
+export const TAB_GAP_PX = 4;
+export const TAB_MAX_WIDTH_PX = 240;
+export const TAB_RESIZE_DURATION_MS = 170;
+export const TAB_RESIZE_EASING = "cubic-bezier(0.22, 1, 0.36, 1)";
+export const TAB_RESIZE_TRANSITION = `width ${TAB_RESIZE_DURATION_MS}ms ${TAB_RESIZE_EASING}`;
 export const DND_MODIFIERS = [
   restrictToHorizontalAxis,
   restrictToParentElement,
 ];
 export const SORTABLE_TAB_TRANSITION = {
-  duration: 170,
-  easing: "cubic-bezier(0.22, 1, 0.36, 1)",
+  duration: TAB_RESIZE_DURATION_MS,
+  easing: TAB_RESIZE_EASING,
 };
 export const TAB_SWITCHER_HEADER_HEIGHT_PX = 240;
 export const MAIN_HEADER_HEIGHT_CSS_VAR = "--main-custom-header-height";

--- a/apps/desktop/src/components/custom-title-bar/git-tab-title.tsx
+++ b/apps/desktop/src/components/custom-title-bar/git-tab-title.tsx
@@ -19,8 +19,8 @@ export const GitTabTitle = ({
 }) => {
   if (!repository) {
     return (
-      <div className="flex items-center gap-1.5 truncate font-medium">
-        <Git className={"size-4"} />
+      <div className="flex min-w-0 items-center gap-1.5 truncate font-medium">
+        <Git className="size-4 shrink-0" />
         <span className="truncate font-medium">Git Repository</span>
       </div>
     );

--- a/apps/desktop/src/components/custom-title-bar/index.tsx
+++ b/apps/desktop/src/components/custom-title-bar/index.tsx
@@ -49,7 +49,7 @@ const CustomTitleBar = ({ restrictedPaths = [] }: CustomTitleBarProps) => {
     >
       <div
         className="absolute inset-x-0 flex min-w-0 items-center"
-        data-tauri-drag-region
+        data-tauri-drag-region="deep"
         style={{
           // @ts-expect-error - ¯\_(ツ)_/¯
           WebkitAppRegion: "drag",

--- a/apps/desktop/src/components/custom-title-bar/index.tsx
+++ b/apps/desktop/src/components/custom-title-bar/index.tsx
@@ -48,12 +48,12 @@ const CustomTitleBar = ({ restrictedPaths = [] }: CustomTitleBarProps) => {
       }}
     >
       <div
-        className="absolute inset-x-0 flex min-w-0 items-center pr-4"
+        className="absolute inset-x-0 flex min-w-0 items-center"
         data-tauri-drag-region
         style={{
           // @ts-expect-error - ¯\_(ツ)_/¯
           WebkitAppRegion: "drag",
-          paddingLeft: "70px",
+          paddingLeft: "90px",
         }}
       >
         <NavigationButtons

--- a/apps/desktop/src/components/custom-title-bar/index.tsx
+++ b/apps/desktop/src/components/custom-title-bar/index.tsx
@@ -48,10 +48,11 @@ const CustomTitleBar = ({ restrictedPaths = [] }: CustomTitleBarProps) => {
       }}
     >
       <div
-        className="absolute flex w-fit items-center pr-4"
+        className="absolute inset-x-0 flex min-w-0 items-center pr-4"
+        data-tauri-drag-region
         style={{
           // @ts-expect-error - ¯\_(ツ)_/¯
-          WebkitAppRegion: "no-drag",
+          WebkitAppRegion: "drag",
           paddingLeft: "70px",
         }}
       >
@@ -64,7 +65,7 @@ const CustomTitleBar = ({ restrictedPaths = [] }: CustomTitleBarProps) => {
           goForward={goForward}
           navigate={navigate}
         />
-        <div className="-translate-x-3 flex w-fit items-center h-[calc(var(--main-custom-header-height)-0px)]">
+        <div className="-translate-x-3 flex h-[calc(var(--main-custom-header-height)-0px)] min-w-0 flex-1 items-center">
           <TabList
             sensors={sensors}
             orderedTabIds={orderedTabIds}

--- a/apps/desktop/src/components/custom-title-bar/navigation-buttons.tsx
+++ b/apps/desktop/src/components/custom-title-bar/navigation-buttons.tsx
@@ -22,7 +22,7 @@ export const NavigationButtons = ({
   goForward,
   navigate,
 }: NavigationButtonsProps) => (
-  <div className="flex items-center mr-3 translate-y-px">
+  <div className="title-bar-no-drag mr-3 flex shrink-0 translate-y-px items-center">
     <Button
       onClick={() => {
         console.log(

--- a/apps/desktop/src/components/custom-title-bar/sortable-tab-shell.tsx
+++ b/apps/desktop/src/components/custom-title-bar/sortable-tab-shell.tsx
@@ -2,18 +2,22 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { type ReactNode } from "react";
 
-import { SORTABLE_TAB_TRANSITION } from "./constants";
+import { SORTABLE_TAB_TRANSITION, TAB_RESIZE_TRANSITION } from "./constants";
 
 type SortableTabShellProps = {
   id: string;
   className?: string;
   children: ReactNode;
+  shouldAnimateWidth: boolean;
+  width: number;
 };
 
 export const SortableTabShell = ({
   id,
   className,
   children,
+  shouldAnimateWidth,
+  width,
 }: SortableTabShellProps) => {
   const {
     attributes,
@@ -26,14 +30,23 @@ export const SortableTabShell = ({
     id,
     transition: SORTABLE_TAB_TRANSITION,
   });
+  const composedTransition = [
+    transition,
+    shouldAnimateWidth ? TAB_RESIZE_TRANSITION : null,
+  ]
+    .filter(Boolean)
+    .join(", ");
 
   return (
     <div
       ref={setNodeRef}
       data-tab-id={id}
       style={{
+        flex: "0 0 auto",
         transform: CSS.Transform.toString(transform),
-        transition,
+        transition: composedTransition || undefined,
+        width,
+        willChange: shouldAnimateWidth ? "width" : undefined,
         zIndex: isDragging ? 30 : undefined,
       }}
       className={className}

--- a/apps/desktop/src/components/custom-title-bar/sortable-tab-shell.tsx
+++ b/apps/desktop/src/components/custom-title-bar/sortable-tab-shell.tsx
@@ -30,6 +30,7 @@ export const SortableTabShell = ({
   return (
     <div
       ref={setNodeRef}
+      data-tab-id={id}
       style={{
         transform: CSS.Transform.toString(transform),
         transition,

--- a/apps/desktop/src/components/custom-title-bar/tab-list.tsx
+++ b/apps/desktop/src/components/custom-title-bar/tab-list.tsx
@@ -21,9 +21,10 @@ import { type RefObject } from "react";
 
 import { TAB_SWITCH_CYCLE_MODE } from "@/lib/tab-switching";
 
-import { DND_MODIFIERS } from "./constants";
+import { DND_MODIFIERS, TAB_RESIZE_TRANSITION } from "./constants";
 import { GitTabTitle } from "./git-tab-title";
 import { SortableTabShell } from "./sortable-tab-shell";
+import { useTabStripLayout } from "./use-tab-strip-layout";
 import { getRoutePathname, isGitRoute } from "./utils";
 
 type TabRecord = {
@@ -81,282 +82,312 @@ export const TabList = ({
   isTabSwitcherOpen,
   tabSwitcherTabIds,
   tabSwitcherIndex,
-}: TabListProps) => (
-  <div
-    data-tab-list="true"
-    className="relative ml-2 flex h-full min-w-0 flex-1 items-center gap-1 pt-1"
-  >
-    <DndContext
-      sensors={sensors}
-      collisionDetection={closestCenter}
-      modifiers={DND_MODIFIERS}
-      onDragStart={handleDragStart}
-      onDragOver={handleDragOver}
-      onDragEnd={handleDragEnd}
-      onDragCancel={handleDragCancel}
+}: TabListProps) => {
+  const { containerRef, controlsRef, layout, shouldAnimateWidth } =
+    useTabStripLayout({
+      isTabDragInProgress,
+      tabCount: orderedTabs.length,
+    });
+
+  return (
+    <div
+      ref={containerRef}
+      data-tab-list="true"
+      className="relative ml-2 flex h-full min-w-0 flex-1 items-center gap-1 pt-1"
     >
-      <SortableContext
-        items={orderedTabIds}
-        strategy={horizontalListSortingStrategy}
+      <div
+        className={cn(
+          "flex h-full shrink-0 items-center gap-1",
+          shouldAnimateWidth && "overflow-hidden",
+        )}
+        style={{
+          transition: shouldAnimateWidth ? TAB_RESIZE_TRANSITION : undefined,
+          width: layout.railWidth,
+          willChange: shouldAnimateWidth ? "width" : undefined,
+        }}
       >
-        {orderedTabs.map((tab, index) => {
-          const isActive = tab.id === activeTabId;
-          const isDraggingTab = tab.id === draggingTabId;
-          const isHovered =
-            tab.id === hoveredTabId && (!isTabDragInProgress || isDraggingTab);
-          const tabRepository = tab.repositoryId
-            ? (repositories.find((repo) => repo.id === tab.repositoryId) ??
-              null)
-            : null;
-          const showGitTitle = isGitRoute(tab.routePath);
-          const nextTab = orderedTabs[index + 1] ?? null;
-          const shouldHideSeparator =
-            !!nextTab &&
-            (isActive ||
-              isHovered ||
-              nextTab.id === activeTabId ||
-              nextTab.id === hoveredTabId);
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          modifiers={DND_MODIFIERS}
+          onDragStart={handleDragStart}
+          onDragOver={handleDragOver}
+          onDragEnd={handleDragEnd}
+          onDragCancel={handleDragCancel}
+        >
+          <SortableContext
+            items={orderedTabIds}
+            strategy={horizontalListSortingStrategy}
+          >
+            {orderedTabs.map((tab, index) => {
+              const isActive = tab.id === activeTabId;
+              const isDraggingTab = tab.id === draggingTabId;
+              const isHovered =
+                tab.id === hoveredTabId &&
+                (!isTabDragInProgress || isDraggingTab);
+              const tabRepository = tab.repositoryId
+                ? (repositories.find((repo) => repo.id === tab.repositoryId) ??
+                  null)
+                : null;
+              const showGitTitle = isGitRoute(tab.routePath);
+              const nextTab = orderedTabs[index + 1] ?? null;
+              const shouldHideSeparator =
+                !!nextTab &&
+                (isActive ||
+                  isHovered ||
+                  nextTab.id === activeTabId ||
+                  nextTab.id === hoveredTabId);
 
-          return (
-            <SortableTabShell
-              key={tab.id}
-              id={tab.id}
-              className="workspace-tab-shell title-bar-no-drag relative h-full min-w-0 max-w-60 flex-[1_1_15rem]"
-            >
-              <div className="relative flex h-full min-w-0 items-end">
-                {isActive && (
-                  <svg
-                    width="15"
-                    height="15"
-                    viewBox="0 0 15 15"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                    className="filter-[drop-shadow(-1.2px_-0.5px_1px_#0000001A)] absolute -left-3.75 bottom-0"
-                  >
-                    <path
-                      d="M15 15H0C8.28427 15 15 8.28427 15 0V15Z"
-                      fill="var(--background)"
-                    />
-                  </svg>
-                )}
-                <div
-                  role="button"
-                  tabIndex={0}
-                  onPointerDownCapture={(event) => {
-                    if (event.button === 1) {
-                      event.stopPropagation();
-                    }
-                  }}
-                  onMouseDown={(event) => {
-                    if (event.button !== 0) {
-                      if (event.button === 1) {
-                        event.preventDefault();
-                        event.stopPropagation();
-                      }
-
-                      return;
-                    }
-
-                    if (suppressClickTabIdRef.current === tab.id) {
-                      suppressClickTabIdRef.current = null;
-                      return;
-                    }
-
-                    void handleActivateTab(tab.id);
-                  }}
-                  onAuxClick={(event) => {
-                    if (event.button !== 1) {
-                      return;
-                    }
-
-                    event.preventDefault();
-                    event.stopPropagation();
-                    void handleCloseTab(tab.id);
-                  }}
-                  onMouseEnter={() => {
-                    if (isTabDragInProgress && !isDraggingTab) {
-                      return;
-                    }
-
-                    setHoveredTabId(tab.id);
-                  }}
-                  onMouseLeave={() => {
-                    if (isTabDragInProgress && !isDraggingTab) {
-                      return;
-                    }
-
-                    setHoveredTabId((currentHoveredTabId) =>
-                      currentHoveredTabId === tab.id
-                        ? null
-                        : currentHoveredTabId,
-                    );
-                  }}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter" || event.key === " ") {
-                      event.preventDefault();
-                      void handleActivateTab(tab.id);
-                    }
-                  }}
-                  className={cn(
-                    "workspace-tab group flex h-full w-full min-w-0 items-center gap-1 rounded-t-2xl pb-1 text-sm touch-none",
-                    isActive
-                      ? "bg-background flex items-center [box-shadow:-1px_-1px_1px_0.1px_#0000001A,1px_-1px_1px_0.1px_#0000001A]"
-                      : "bg-transparent text-muted-foreground",
-                  )}
+              return (
+                <SortableTabShell
+                  key={tab.id}
+                  id={tab.id}
+                  shouldAnimateWidth={shouldAnimateWidth}
+                  width={layout.tabWidth}
+                  className="workspace-tab-shell title-bar-no-drag relative h-full min-w-0"
                 >
-                  <div
-                    className={cn(
-                      "flex h-full w-full min-w-0 max-w-full items-center gap-1 rounded-[12px] pr-1 pl-1.5",
-                      !isActive &&
-                        (!isTabDragInProgress || isDraggingTab) &&
-                        "hover:bg-foreground/10",
+                  <div className="relative flex h-full min-w-0 items-end">
+                    {isActive && (
+                      <svg
+                        width="15"
+                        height="15"
+                        viewBox="0 0 15 15"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                        className="filter-[drop-shadow(-1.2px_-0.5px_1px_#0000001A)] absolute -left-3.75 bottom-0"
+                      >
+                        <path
+                          d="M15 15H0C8.28427 15 15 8.28427 15 0V15Z"
+                          fill="var(--background)"
+                        />
+                      </svg>
                     )}
-                  >
-                    {showGitTitle ? (
-                      <GitTabTitle
-                        repository={tabRepository}
-                        isActive={isActive}
-                      />
-                    ) : tab.routePath === "/app/inbox" ? (
-                      <div className="flex min-w-0 items-center gap-1.5">
-                        <Inbox className="size-4 shrink-0" />
-                        <span className="truncate">
-                          Inbox{" "}
-                          <span className="text-muted-foreground/70">(5)</span>
-                        </span>
-                      </div>
-                    ) : (
-                      <span className="truncate font-medium">{tab.title}</span>
-                    )}
-                    <Button
-                      size={"icon-xs"}
-                      variant={"ghost"}
-                      data-tab-close-button="true"
-                      data-active={isActive}
-                      aria-label={`Close ${tab.title}`}
-                      className={cn(
-                        "workspace-tab-close ms-auto h-5 w-5 shrink-0 rounded-full",
-                        isActive
-                          ? "text-muted-foreground hover:text-foreground"
-                          : "text-muted-foreground/70",
-                      )}
-                      onMouseDown={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                      }}
+                    <div
+                      role="button"
+                      tabIndex={0}
                       onPointerDownCapture={(event) => {
-                        event.stopPropagation();
+                        if (event.button === 1) {
+                          event.stopPropagation();
+                        }
                       }}
-                      onClick={(event) => {
+                      onMouseDown={(event) => {
+                        if (event.button !== 0) {
+                          if (event.button === 1) {
+                            event.preventDefault();
+                            event.stopPropagation();
+                          }
+
+                          return;
+                        }
+
+                        if (suppressClickTabIdRef.current === tab.id) {
+                          suppressClickTabIdRef.current = null;
+                          return;
+                        }
+
+                        void handleActivateTab(tab.id);
+                      }}
+                      onAuxClick={(event) => {
+                        if (event.button !== 1) {
+                          return;
+                        }
+
                         event.preventDefault();
                         event.stopPropagation();
                         void handleCloseTab(tab.id);
                       }}
+                      onMouseEnter={() => {
+                        if (isTabDragInProgress && !isDraggingTab) {
+                          return;
+                        }
+
+                        setHoveredTabId(tab.id);
+                      }}
+                      onMouseLeave={() => {
+                        if (isTabDragInProgress && !isDraggingTab) {
+                          return;
+                        }
+
+                        setHoveredTabId((currentHoveredTabId) =>
+                          currentHoveredTabId === tab.id
+                            ? null
+                            : currentHoveredTabId,
+                        );
+                      }}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter" || event.key === " ") {
+                          event.preventDefault();
+                          void handleActivateTab(tab.id);
+                        }
+                      }}
+                      className={cn(
+                        "workspace-tab group flex h-full w-full min-w-0 items-center gap-1 rounded-t-2xl pb-1 text-sm touch-none",
+                        isActive
+                          ? "bg-background flex items-center [box-shadow:-1px_-1px_1px_0.1px_#0000001A,1px_-1px_1px_0.1px_#0000001A]"
+                          : "bg-transparent text-muted-foreground",
+                      )}
                     >
-                      <X size={12} aria-hidden="true" />
-                    </Button>
+                      <div
+                        className={cn(
+                          "flex h-full w-full min-w-0 max-w-full items-center gap-1 rounded-[12px] pr-1 pl-1.5",
+                          !isActive &&
+                            (!isTabDragInProgress || isDraggingTab) &&
+                            "hover:bg-foreground/10",
+                        )}
+                      >
+                        {showGitTitle ? (
+                          <GitTabTitle
+                            repository={tabRepository}
+                            isActive={isActive}
+                          />
+                        ) : tab.routePath === "/app/inbox" ? (
+                          <div className="flex min-w-0 items-center gap-1.5">
+                            <Inbox className="size-4 shrink-0" />
+                            <span className="truncate">
+                              Inbox{" "}
+                              <span className="text-muted-foreground/70">
+                                (5)
+                              </span>
+                            </span>
+                          </div>
+                        ) : (
+                          <span className="truncate font-medium">
+                            {tab.title}
+                          </span>
+                        )}
+                        <Button
+                          size={"icon-xs"}
+                          variant={"ghost"}
+                          data-tab-close-button="true"
+                          data-active={isActive}
+                          aria-label={`Close ${tab.title}`}
+                          className={cn(
+                            "workspace-tab-close ms-auto h-5 w-5 shrink-0 rounded-full",
+                            isActive
+                              ? "text-muted-foreground hover:text-foreground"
+                              : "text-muted-foreground/70",
+                          )}
+                          onMouseDown={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                          }}
+                          onPointerDownCapture={(event) => {
+                            event.stopPropagation();
+                          }}
+                          onClick={(event) => {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            void handleCloseTab(tab.id);
+                          }}
+                        >
+                          <X size={12} aria-hidden="true" />
+                        </Button>
+                      </div>
+                    </div>
+                    {isActive && (
+                      <svg
+                        width="15"
+                        height="15"
+                        viewBox="0 0 15 15"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                        className="filter-[drop-shadow(1.2px_-0.5px_1px_#0000001A)] absolute -right-3.75 bottom-0"
+                      >
+                        <path
+                          d="M0 15L6.5568e-07 0C2.93563e-07 8.28427 6.71573 15 15 15L0 15Z"
+                          fill="var(--background)"
+                        />
+                      </svg>
+                    )}
                   </div>
-                </div>
-                {isActive && (
-                  <svg
-                    width="15"
-                    height="15"
-                    viewBox="0 0 15 15"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                    className="filter-[drop-shadow(1.2px_-0.5px_1px_#0000001A)] absolute -right-3.75 bottom-0"
-                  >
-                    <path
-                      d="M0 15L6.5568e-07 0C2.93563e-07 8.28427 6.71573 15 15 15L0 15Z"
-                      fill="var(--background)"
+                  {nextTab ? (
+                    <div
+                      aria-hidden="true"
+                      className={cn(
+                        "absolute -right-px bottom-2",
+                        "w-0.5 h-4 bg-foreground/5 mb-1 transition-opacity",
+                        shouldHideSeparator && "opacity-0",
+                      )}
                     />
-                  </svg>
-                )}
-              </div>
-              {nextTab ? (
-                <div
-                  aria-hidden="true"
-                  className={cn(
-                    "absolute -right-px bottom-2",
-                    "w-0.5 h-4 bg-foreground/5 mb-1 transition-opacity",
-                    shouldHideSeparator && "opacity-0",
-                  )}
-                />
-              ) : null}
-            </SortableTabShell>
-          );
-        })}
-      </SortableContext>
-    </DndContext>
-
-    {TAB_SWITCH_CYCLE_MODE === "MRU" &&
-    isTabSwitcherOpen &&
-    tabSwitcherTabIds.length > 0 ? (
-      <div className="pointer-events-none absolute left-1/2 top-12 z-50 -translate-x-1/2">
-        <div className="min-w-80 max-w-136 overflow-hidden rounded-xl border border-border/60 bg-background/95 p-1.5 shadow-2xl backdrop-blur">
-          <div className="border-b border-border/50 px-2 py-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-            Recent Tabs
-          </div>
-          <div className="flex max-h-44 flex-col gap-0.5 overflow-auto p-1">
-            {tabSwitcherTabIds.map((tabId, index) => {
-              const switcherTab = tabById.get(tabId);
-
-              if (!switcherTab) {
-                return null;
-              }
-
-              const switcherTabRepository = switcherTab.repositoryId
-                ? (repositories.find(
-                    (repo) => repo.id === switcherTab.repositoryId,
-                  ) ?? null)
-                : null;
-              const title = isGitRoute(switcherTab.routePath)
-                ? (switcherTabRepository?.name ?? "Git")
-                : switcherTab.title;
-              const subtitle = getRoutePathname(switcherTab.routePath);
-              const isSelected = index === tabSwitcherIndex;
-
-              return (
-                <div
-                  key={tabId}
-                  className={cn(
-                    "flex min-w-0 items-center gap-3 rounded-md px-2 py-1.5 text-sm",
-                    isSelected
-                      ? "bg-foreground/10 text-foreground"
-                      : "text-muted-foreground",
-                  )}
-                >
-                  <span className="min-w-0 flex-1 truncate font-medium">
-                    {title}
-                  </span>
-                  <span className="max-w-56 truncate text-xs text-muted-foreground">
-                    {subtitle}
-                  </span>
-                </div>
+                  ) : null}
+                </SortableTabShell>
               );
             })}
+          </SortableContext>
+        </DndContext>
+      </div>
+
+      {TAB_SWITCH_CYCLE_MODE === "MRU" &&
+      isTabSwitcherOpen &&
+      tabSwitcherTabIds.length > 0 ? (
+        <div className="pointer-events-none absolute left-1/2 top-12 z-50 -translate-x-1/2">
+          <div className="min-w-80 max-w-136 overflow-hidden rounded-xl border border-border/60 bg-background/95 p-1.5 shadow-2xl backdrop-blur">
+            <div className="border-b border-border/50 px-2 py-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+              Recent Tabs
+            </div>
+            <div className="flex max-h-44 flex-col gap-0.5 overflow-auto p-1">
+              {tabSwitcherTabIds.map((tabId, index) => {
+                const switcherTab = tabById.get(tabId);
+
+                if (!switcherTab) {
+                  return null;
+                }
+
+                const switcherTabRepository = switcherTab.repositoryId
+                  ? (repositories.find(
+                      (repo) => repo.id === switcherTab.repositoryId,
+                    ) ?? null)
+                  : null;
+                const title = isGitRoute(switcherTab.routePath)
+                  ? (switcherTabRepository?.name ?? "Git")
+                  : switcherTab.title;
+                const subtitle = getRoutePathname(switcherTab.routePath);
+                const isSelected = index === tabSwitcherIndex;
+
+                return (
+                  <div
+                    key={tabId}
+                    className={cn(
+                      "flex min-w-0 items-center gap-3 rounded-md px-2 py-1.5 text-sm",
+                      isSelected
+                        ? "bg-foreground/10 text-foreground"
+                        : "text-muted-foreground",
+                    )}
+                  >
+                    <span className="min-w-0 flex-1 truncate font-medium">
+                      {title}
+                    </span>
+                    <span className="max-w-56 truncate text-xs text-muted-foreground">
+                      {subtitle}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
           </div>
         </div>
+      ) : null}
+
+      <div ref={controlsRef} className="flex shrink-0 items-center gap-1">
+        <div
+          aria-hidden="true"
+          className={cn(
+            "mb-1 h-4 w-0.5 shrink-0 bg-foreground/5 transition-opacity",
+          )}
+        />
+
+        <Button
+          size={"icon-sm"}
+          variant={"ghost"}
+          aria-label="New tab"
+          className="title-bar-no-drag mb-1 shrink-0 text-muted-foreground/70"
+          onClick={() => {
+            void handleCreateTab();
+          }}
+        >
+          <Plus size={16} aria-hidden="true" />
+        </Button>
       </div>
-    ) : null}
-
-    <div
-      aria-hidden="true"
-      className={cn(
-        "mb-1 h-4 w-0.5 shrink-0 bg-foreground/5 transition-opacity",
-      )}
-    />
-
-    <Button
-      size={"icon-sm"}
-      variant={"ghost"}
-      aria-label="New tab"
-      className="title-bar-no-drag mb-1 shrink-0 text-muted-foreground/70"
-      onClick={() => {
-        void handleCreateTab();
-      }}
-    >
-      <Plus size={16} aria-hidden="true" />
-    </Button>
-  </div>
-);
+    </div>
+  );
+};

--- a/apps/desktop/src/components/custom-title-bar/tab-list.tsx
+++ b/apps/desktop/src/components/custom-title-bar/tab-list.tsx
@@ -85,7 +85,10 @@ export const TabList = ({
   tabSwitcherTabIds,
   tabSwitcherIndex,
 }: TabListProps) => (
-  <div className="relative ml-2 flex min-w-0 flex-1 items-center gap-1 h-full pt-1">
+  <div
+    data-tab-list="true"
+    className="relative ml-2 flex h-full min-w-0 flex-1 items-center gap-1 pt-1"
+  >
     <DndContext
       sensors={sensors}
       collisionDetection={closestCenter}
@@ -121,12 +124,9 @@ export const TabList = ({
             <SortableTabShell
               key={tab.id}
               id={tab.id}
-              className={cn(
-                "relative h-full",
-                isDraggingTab ? "" : "transition-all",
-              )}
+              className="workspace-tab-shell title-bar-no-drag relative h-full min-w-0 max-w-72 flex-[1_1_18rem]"
             >
-              <div className="relative flex items-end h-full">
+              <div className="relative flex h-full min-w-0 items-end">
                 {isActive && (
                   <svg
                     width="15"
@@ -178,7 +178,7 @@ export const TabList = ({
                     }
                   }}
                   className={cn(
-                    "group flex h-full min-w-44 max-w-72 shrink-0 items-center gap-1 text-sm rounded-t-2xl pb-1 touch-none",
+                    "workspace-tab group flex h-full w-full min-w-0 items-center gap-1 rounded-t-2xl pb-1 text-sm touch-none",
                     isActive
                       ? "bg-background flex items-center [box-shadow:-1px_-1px_1px_0.1px_#0000001A,1px_-1px_1px_0.1px_#0000001A]"
                       : "bg-transparent text-muted-foreground",
@@ -186,7 +186,7 @@ export const TabList = ({
                 >
                   <div
                     className={cn(
-                      "flex max-w-full w-full items-center gap-1 h-full pl-1.5 pr-1 rounded-[12px]",
+                      "flex h-full w-full min-w-0 max-w-full items-center gap-1 rounded-[12px] pr-1 pl-1.5",
                       !isActive &&
                         (!isTabDragInProgress || isDraggingTab) &&
                         "hover:bg-foreground/10",
@@ -198,9 +198,9 @@ export const TabList = ({
                         isActive={isActive}
                       />
                     ) : tab.routePath === "/app/inbox" ? (
-                      <div className="flex items-center gap-1.5">
-                        <Inbox className={"size-4"} />
-                        <span>
+                      <div className="flex min-w-0 items-center gap-1.5">
+                        <Inbox className="size-4 shrink-0" />
+                        <span className="truncate">
                           Inbox{" "}
                           <span className="text-muted-foreground/70">(5)</span>
                         </span>
@@ -212,8 +212,10 @@ export const TabList = ({
                       size={"icon-xs"}
                       variant={"ghost"}
                       data-tab-close-button="true"
+                      data-active={isActive}
+                      aria-label={`Close ${tab.title}`}
                       className={cn(
-                        "ms-auto h-5 w-5 rounded-full",
+                        "workspace-tab-close ms-auto h-5 w-5 shrink-0 rounded-full",
                         isActive
                           ? "text-muted-foreground hover:text-foreground"
                           : "text-muted-foreground/70",
@@ -320,13 +322,16 @@ export const TabList = ({
 
     <div
       aria-hidden="true"
-      className={cn("w-0.5 h-4 bg-foreground/5 mb-1 transition-opacity")}
+      className={cn(
+        "mb-1 h-4 w-0.5 shrink-0 bg-foreground/5 transition-opacity",
+      )}
     />
 
     <Button
       size={"icon-sm"}
       variant={"ghost"}
-      className="mb-1 text-muted-foreground/70"
+      aria-label="New tab"
+      className="title-bar-no-drag mb-1 shrink-0 text-muted-foreground/70"
       onClick={() => {
         void handleCreateTab();
       }}

--- a/apps/desktop/src/components/custom-title-bar/tab-list.tsx
+++ b/apps/desktop/src/components/custom-title-bar/tab-list.tsx
@@ -17,7 +17,7 @@ import { Inbox } from "@gitru/icon";
 import { Button } from "@gitru/ui/components/button";
 import { cn } from "@gitru/ui/lib/utils";
 import { Plus, X } from "lucide-react";
-import { type MouseEvent, type RefObject } from "react";
+import { type RefObject } from "react";
 
 import { TAB_SWITCH_CYCLE_MODE } from "@/lib/tab-switching";
 
@@ -49,10 +49,7 @@ type TabListProps = {
   repositories: RepositoryInfo[];
   handleActivateTab: (tabId: string) => Promise<void>;
   handleCreateTab: () => Promise<void>;
-  handleCloseTab: (
-    tabId: string,
-    event: MouseEvent<HTMLButtonElement>,
-  ) => Promise<void>;
+  handleCloseTab: (tabId: string) => Promise<void>;
   handleDragStart: (event: DragStartEvent) => void;
   handleDragOver: (event: DragOverEvent) => void;
   handleDragEnd: (event: DragEndEvent) => void;
@@ -145,13 +142,36 @@ export const TabList = ({
                 <div
                   role="button"
                   tabIndex={0}
-                  onMouseDown={() => {
+                  onPointerDownCapture={(event) => {
+                    if (event.button === 1) {
+                      event.stopPropagation();
+                    }
+                  }}
+                  onMouseDown={(event) => {
+                    if (event.button !== 0) {
+                      if (event.button === 1) {
+                        event.preventDefault();
+                        event.stopPropagation();
+                      }
+
+                      return;
+                    }
+
                     if (suppressClickTabIdRef.current === tab.id) {
                       suppressClickTabIdRef.current = null;
                       return;
                     }
 
                     void handleActivateTab(tab.id);
+                  }}
+                  onAuxClick={(event) => {
+                    if (event.button !== 1) {
+                      return;
+                    }
+
+                    event.preventDefault();
+                    event.stopPropagation();
+                    void handleCloseTab(tab.id);
                   }}
                   onMouseEnter={() => {
                     if (isTabDragInProgress && !isDraggingTab) {
@@ -230,7 +250,7 @@ export const TabList = ({
                       onClick={(event) => {
                         event.preventDefault();
                         event.stopPropagation();
-                        void handleCloseTab(tab.id, event);
+                        void handleCloseTab(tab.id);
                       }}
                     >
                       <X size={12} aria-hidden="true" />

--- a/apps/desktop/src/components/custom-title-bar/tab-list.tsx
+++ b/apps/desktop/src/components/custom-title-bar/tab-list.tsx
@@ -121,7 +121,7 @@ export const TabList = ({
             <SortableTabShell
               key={tab.id}
               id={tab.id}
-              className="workspace-tab-shell title-bar-no-drag relative h-full min-w-0 max-w-72 flex-[1_1_18rem]"
+              className="workspace-tab-shell title-bar-no-drag relative h-full min-w-0 max-w-60 flex-[1_1_15rem]"
             >
               <div className="relative flex h-full min-w-0 items-end">
                 {isActive && (

--- a/apps/desktop/src/components/custom-title-bar/tab-strip-layout.ts
+++ b/apps/desktop/src/components/custom-title-bar/tab-strip-layout.ts
@@ -1,0 +1,37 @@
+import { TAB_GAP_PX, TAB_MAX_WIDTH_PX } from "./constants";
+
+type ResolveTabStripLayoutOptions = {
+  containerWidth: number;
+  controlsWidth: number;
+  tabCount: number;
+};
+
+export type TabStripLayout = {
+  railWidth: number;
+  tabWidth: number;
+};
+
+export const resolveTabStripLayout = ({
+  containerWidth,
+  controlsWidth,
+  tabCount,
+}: ResolveTabStripLayoutOptions): TabStripLayout => {
+  if (tabCount <= 0) {
+    return { railWidth: 0, tabWidth: 0 };
+  }
+
+  const availableWidth = Math.max(
+    0,
+    containerWidth - controlsWidth - TAB_GAP_PX,
+  );
+  const totalTabGaps = TAB_GAP_PX * Math.max(0, tabCount - 1);
+  const tabWidth = Math.min(
+    TAB_MAX_WIDTH_PX,
+    Math.max(0, (availableWidth - totalTabGaps) / tabCount),
+  );
+
+  return {
+    railWidth: Math.min(availableWidth, tabWidth * tabCount + totalTabGaps),
+    tabWidth,
+  };
+};

--- a/apps/desktop/src/components/custom-title-bar/use-custom-title-bar.ts
+++ b/apps/desktop/src/components/custom-title-bar/use-custom-title-bar.ts
@@ -11,11 +11,12 @@ import { arrayMove } from "@dnd-kit/sortable";
 import { type RepositoryInfo } from "@gitru/commands";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
-import { type MouseEvent, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { useRepositories } from "@/hooks/use-repositories";
 import { useSessionNavigation } from "@/hooks/use-session-navigation";
 import {
+  resolveTabManagementShortcut,
   TAB_SWITCH_CYCLE_MODE,
   TAB_SWITCH_SHORTCUT_EVENT,
   type TabSwitchShortcutPayload,
@@ -57,7 +58,6 @@ export function useCustomTitleBar() {
   const ensureActiveTab = useAppStore((state) => state.ensureActiveTab);
   const createTab = useAppStore((state) => state.createTab);
   const activateTab = useAppStore((state) => state.activateTab);
-  const closeTab = useAppStore((state) => state.closeTab);
   const reorderTab = useAppStore((state) => state.reorderTab);
   const syncActiveTab = useAppStore((state) => state.syncActiveTab);
   const suppressClickTabIdRef = useRef<string | null>(null);
@@ -78,6 +78,8 @@ export function useCustomTitleBar() {
     (_backward: boolean, _modifier: TabSwitchModifier) => {},
   );
   const handleTabSwitchCommitRef = useRef(() => {});
+  const handleCreateTabRef = useRef(() => {});
+  const handleCloseActiveTabRef = useRef(() => {});
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: {
@@ -107,13 +109,17 @@ export function useCustomTitleBar() {
   const shouldReserveTabSwitcherSpace =
     isRootShellMode && TAB_SWITCH_CYCLE_MODE === "MRU" && isTabSwitcherOpen;
 
-  const disposeRuntimeForTab = (tabId: string) => {
-    const tab = tabs.find((item) => item.id === tabId);
+  const disposeRuntimeForTab = (
+    tabId: string,
+    repositoryId: string | null | undefined,
+  ) => {
     const contextEntry = repoContextRegistry.getScopeContext(tabId);
 
-    if (tab?.repositoryId && contextEntry?.contextId) {
+    if (repositoryId && contextEntry?.contextId) {
       const repository =
-        repositories.find((repo) => repo.id === tab.repositoryId) ?? null;
+        useAppStore
+          .getState()
+          .repositories.find((repo) => repo.id === repositoryId) ?? null;
 
       if (repository?.path) {
         void appState.repositories.dispose(
@@ -287,23 +293,16 @@ export function useCustomTitleBar() {
     });
   };
 
-  const handleCloseTab = async (
-    tabId: string,
-    event: MouseEvent<HTMLButtonElement>,
-  ) => {
-    event.stopPropagation();
+  const handleCloseTab = async (tabId: string) => {
+    const currentState = useAppStore.getState();
+    const tab = currentState.tabs.find((item) => item.id === tabId);
 
-    if (tabs.length <= 1) {
+    if (currentState.tabs.length <= 1 || !tab) {
       return;
     }
 
-    const wasActive = tabId === activeTabId;
-    closeTab(tabId);
-    disposeRuntimeForTab(tabId);
-
-    if (!wasActive) {
-      return;
-    }
+    currentState.closeTab(tabId);
+    disposeRuntimeForTab(tabId, tab.repositoryId);
   };
 
   const getMruCandidateTabIds = () => {
@@ -427,6 +426,16 @@ export function useCustomTitleBar() {
   useEffect(() => {
     handleTabSwitchAdvanceRef.current = handleTabSwitchAdvance;
     handleTabSwitchCommitRef.current = handleTabSwitchCommit;
+    handleCreateTabRef.current = () => {
+      void handleCreateTab();
+    };
+    handleCloseActiveTabRef.current = () => {
+      const currentActiveTabId = useAppStore.getState().activeTabId;
+
+      if (currentActiveTabId) {
+        void handleCloseTab(currentActiveTabId);
+      }
+    };
   });
 
   useEffect(() => {
@@ -456,6 +465,21 @@ export function useCustomTitleBar() {
     }
 
     const handleKeyDown = (event: KeyboardEvent) => {
+      const managementShortcut = resolveTabManagementShortcut(event);
+
+      if (managementShortcut) {
+        event.preventDefault();
+        event.stopPropagation();
+
+        if (managementShortcut === "create") {
+          handleCreateTabRef.current();
+        } else {
+          handleCloseActiveTabRef.current();
+        }
+
+        return;
+      }
+
       if (
         TAB_SWITCH_CYCLE_MODE === "MRU" &&
         event.key === "Escape" &&
@@ -497,10 +521,11 @@ export function useCustomTitleBar() {
     window.addEventListener("keyup", handleKeyUp, true);
     window.addEventListener("blur", handleWindowBlur);
 
+    let disposed = false;
     let unlistenTabSwitchShortcut: (() => void) | undefined;
 
     const registerTabSwitchShortcutListener = async () => {
-      unlistenTabSwitchShortcut =
+      const unlisten =
         await getCurrentWebview().listen<TabSwitchShortcutPayload>(
           TAB_SWITCH_SHORTCUT_EVENT,
           ({ payload }) => {
@@ -516,14 +541,34 @@ export function useCustomTitleBar() {
               return;
             }
 
-            handleTabSwitchCommitRef.current();
+            if (payload.phase === "commit") {
+              handleTabSwitchCommitRef.current();
+              return;
+            }
+
+            if (payload.phase === "create") {
+              handleCreateTabRef.current();
+              return;
+            }
+
+            if (payload.phase === "close") {
+              handleCloseActiveTabRef.current();
+            }
           },
         );
+
+      if (disposed) {
+        unlisten();
+        return;
+      }
+
+      unlistenTabSwitchShortcut = unlisten;
     };
 
     void registerTabSwitchShortcutListener();
 
     return () => {
+      disposed = true;
       window.removeEventListener("keydown", handleKeyDown, true);
       window.removeEventListener("keyup", handleKeyUp, true);
       window.removeEventListener("blur", handleWindowBlur);

--- a/apps/desktop/src/components/custom-title-bar/use-tab-strip-layout.ts
+++ b/apps/desktop/src/components/custom-title-bar/use-tab-strip-layout.ts
@@ -1,0 +1,201 @@
+import { useReducedMotion } from "motion/react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+
+import { useAppStore } from "@/store/use-app-store";
+
+import { TAB_MAX_WIDTH_PX, TAB_RESIZE_DURATION_MS } from "./constants";
+import { resolveTabStripLayout, type TabStripLayout } from "./tab-strip-layout";
+
+type UseTabStripLayoutOptions = {
+  isTabDragInProgress: boolean;
+  tabCount: number;
+};
+
+const INITIAL_LAYOUT: TabStripLayout = {
+  railWidth: 0,
+  tabWidth: TAB_MAX_WIDTH_PX,
+};
+
+const layoutsMatch = (left: TabStripLayout, right: TabStripLayout) =>
+  left.railWidth === right.railWidth && left.tabWidth === right.tabWidth;
+
+export const useTabStripLayout = ({
+  isTabDragInProgress,
+  tabCount,
+}: UseTabStripLayoutOptions) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const controlsRef = useRef<HTMLDivElement>(null);
+  const tabCountRef = useRef(tabCount);
+  const previousTabCountRef = useRef(tabCount);
+  const animationFrameRef = useRef<number | null>(null);
+  const animationTimerRef = useRef<number | null>(null);
+  const isAnimatingRef = useRef(false);
+  const shouldReduceMotion = useReducedMotion();
+  const [isHydrated, setIsHydrated] = useState(() =>
+    useAppStore.persist.hasHydrated(),
+  );
+  const [layout, setLayout] = useState(INITIAL_LAYOUT);
+  const [shouldAnimateWidth, setShouldAnimateWidth] = useState(false);
+
+  tabCountRef.current = tabCount;
+
+  const applyLayout = (nextLayout: TabStripLayout) => {
+    setLayout((currentLayout) =>
+      layoutsMatch(currentLayout, nextLayout) ? currentLayout : nextLayout,
+    );
+  };
+
+  const readLayout = () => {
+    const container = containerRef.current;
+    const controls = controlsRef.current;
+
+    if (!container || !controls) {
+      return null;
+    }
+
+    return resolveTabStripLayout({
+      containerWidth: container.clientWidth,
+      controlsWidth: controls.getBoundingClientRect().width,
+      tabCount: tabCountRef.current,
+    });
+  };
+
+  const stopAnimation = () => {
+    if (animationFrameRef.current !== null) {
+      window.cancelAnimationFrame(animationFrameRef.current);
+      animationFrameRef.current = null;
+    }
+
+    if (animationTimerRef.current !== null) {
+      window.clearTimeout(animationTimerRef.current);
+      animationTimerRef.current = null;
+    }
+
+    isAnimatingRef.current = false;
+    setShouldAnimateWidth(false);
+  };
+
+  const scheduleAnimationEnd = () => {
+    if (animationTimerRef.current !== null) {
+      window.clearTimeout(animationTimerRef.current);
+    }
+
+    animationTimerRef.current = window.setTimeout(() => {
+      animationTimerRef.current = null;
+      isAnimatingRef.current = false;
+      setShouldAnimateWidth(false);
+    }, TAB_RESIZE_DURATION_MS);
+  };
+
+  useEffect(() => {
+    if (isHydrated) {
+      return;
+    }
+
+    let hydrationFrame: number | null = null;
+    const markHydratedAfterPaint = () => {
+      hydrationFrame = window.requestAnimationFrame(() => {
+        setIsHydrated(true);
+      });
+    };
+
+    if (useAppStore.persist.hasHydrated()) {
+      markHydratedAfterPaint();
+
+      return () => {
+        if (hydrationFrame !== null) {
+          window.cancelAnimationFrame(hydrationFrame);
+        }
+      };
+    }
+
+    const unsubscribe = useAppStore.persist.onFinishHydration(
+      markHydratedAfterPaint,
+    );
+
+    return () => {
+      unsubscribe();
+      if (hydrationFrame !== null) {
+        window.cancelAnimationFrame(hydrationFrame);
+      }
+    };
+  }, [isHydrated]);
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    const controls = controlsRef.current;
+
+    if (!container || !controls) {
+      return;
+    }
+
+    const updateForResize = () => {
+      stopAnimation();
+      const nextLayout = readLayout();
+
+      if (nextLayout) {
+        applyLayout(nextLayout);
+      }
+    };
+
+    updateForResize();
+
+    const observer = new ResizeObserver(updateForResize);
+    observer.observe(container);
+    observer.observe(controls);
+
+    return () => {
+      observer.disconnect();
+      stopAnimation();
+    };
+  }, []);
+
+  useLayoutEffect(() => {
+    const didTabCountChange = previousTabCountRef.current !== tabCount;
+    previousTabCountRef.current = tabCount;
+
+    if (!didTabCountChange) {
+      if (isTabDragInProgress || shouldReduceMotion) {
+        stopAnimation();
+      }
+      return;
+    }
+
+    const nextLayout = readLayout();
+
+    if (!nextLayout) {
+      return;
+    }
+
+    if (!isHydrated || isTabDragInProgress || shouldReduceMotion) {
+      stopAnimation();
+      applyLayout(nextLayout);
+      return;
+    }
+
+    if (animationFrameRef.current !== null) {
+      window.cancelAnimationFrame(animationFrameRef.current);
+      animationFrameRef.current = null;
+    }
+
+    if (isAnimatingRef.current) {
+      applyLayout(nextLayout);
+      scheduleAnimationEnd();
+    } else {
+      animationFrameRef.current = window.requestAnimationFrame(() => {
+        animationFrameRef.current = null;
+        isAnimatingRef.current = true;
+        setShouldAnimateWidth(true);
+        applyLayout(nextLayout);
+        scheduleAnimationEnd();
+      });
+    }
+  }, [isHydrated, isTabDragInProgress, shouldReduceMotion, tabCount]);
+
+  return {
+    containerRef,
+    controlsRef,
+    layout,
+    shouldAnimateWidth,
+  };
+};

--- a/apps/desktop/src/components/webview-tab-host.tsx
+++ b/apps/desktop/src/components/webview-tab-host.tsx
@@ -1,9 +1,9 @@
 import { LogicalPosition, LogicalSize } from "@tauri-apps/api/dpi";
 import { Webview } from "@tauri-apps/api/webview";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useAppStore } from "@/store/use-app-store";
-import { WorkspaceTab } from "@/types/store";
+import type { WorkspaceTab } from "@/types/store";
 
 type HostBounds = {
   x: number;
@@ -14,15 +14,20 @@ type HostBounds = {
 
 type ManagedWebview = {
   tabId: string;
-  routePath: string;
   webview: Webview;
   ready: Promise<void>;
+  bounds: HostBounds;
 };
 
 const WEBVIEW_LABEL_PREFIX = "tab-webview:";
+const CREATE_TIMEOUT_MS = 1200;
 
 const managedWebviews = new Map<string, ManagedWebview>();
 const ensureInFlightByTabId = new Map<string, Promise<ManagedWebview | null>>();
+let desiredActiveTabId: string | null = null;
+let visibleTabId: string | null = null;
+let liveTabIds = new Set<string>();
+let pendingCleanupTimer: number | null = null;
 
 const sanitizeWebviewLabel = (tabId: string) =>
   `${WEBVIEW_LABEL_PREFIX}${tabId.replace(/[^a-zA-Z0-9\-/:_]/g, "_")}`;
@@ -37,10 +42,7 @@ const getRoutePathname = (routePath: string) => {
 
 const normalizeWorkspaceRoutePath = (routePath: string) => {
   const pathname = getRoutePathname(routePath);
-  if (pathname === "/app" || pathname === "/app/") {
-    return "/app/git";
-  }
-  return routePath;
+  return pathname === "/app" || pathname === "/app/" ? "/app/git" : routePath;
 };
 
 const toChildWebviewPath = (routePath: string) => {
@@ -56,12 +58,23 @@ const normalizeBounds = (bounds: HostBounds): HostBounds => ({
   height: Math.max(1, Math.round(bounds.height)),
 });
 
-const setWebviewBounds = async (webview: Webview, bounds: HostBounds) => {
-  const normalized = normalizeBounds(bounds);
+const areSameBounds = (left: HostBounds, right: HostBounds) =>
+  left.x === right.x &&
+  left.y === right.y &&
+  left.width === right.width &&
+  left.height === right.height;
 
+const updateManagedBounds = async (
+  entry: ManagedWebview,
+  bounds: HostBounds,
+) => {
+  const normalized = normalizeBounds(bounds);
+  if (areSameBounds(entry.bounds, normalized)) return;
+
+  entry.bounds = normalized;
   await Promise.allSettled([
-    webview.setPosition(new LogicalPosition(normalized.x, normalized.y)),
-    webview.setSize(new LogicalSize(normalized.width, normalized.height)),
+    entry.webview.setPosition(new LogicalPosition(normalized.x, normalized.y)),
+    entry.webview.setSize(new LogicalSize(normalized.width, normalized.height)),
   ]);
 };
 
@@ -69,69 +82,64 @@ const closeManagedWebview = async (entry: ManagedWebview) => {
   await Promise.allSettled([entry.webview.close()]);
 };
 
+const hideUnlessActive = async (entry: ManagedWebview) => {
+  if (entry.tabId !== desiredActiveTabId) {
+    await Promise.allSettled([entry.webview.hide()]);
+  }
+};
+
 const ensureTabWebview = async (
   tab: WorkspaceTab,
   bounds: HostBounds,
 ): Promise<ManagedWebview | null> => {
-  const existingEnsure = ensureInFlightByTabId.get(tab.id);
-  if (existingEnsure) {
-    const pending = await existingEnsure;
-    if (pending) {
-      await setWebviewBounds(pending.webview, bounds);
-    }
-    return pending;
+  const existing = managedWebviews.get(tab.id);
+  if (existing) {
+    await existing.ready;
+    return managedWebviews.get(tab.id) ?? null;
   }
 
+  const existingEnsure = ensureInFlightByTabId.get(tab.id);
+  if (existingEnsure) return await existingEnsure;
+
   const task = (async (): Promise<ManagedWebview | null> => {
-    const normalizedRoutePath = normalizeWorkspaceRoutePath(tab.routePath);
-    const existing = managedWebviews.get(tab.id);
-
-    if (existing) {
-      if (existing.routePath !== normalizedRoutePath) {
-        existing.routePath = normalizedRoutePath;
-      }
-
-      await setWebviewBounds(existing.webview, bounds);
-      return existing;
-    }
-
+    const normalized = normalizeBounds(bounds);
     const label = sanitizeWebviewLabel(tab.id);
     const existingByLabel = await Webview.getByLabel(label);
 
     if (existingByLabel) {
       const reused: ManagedWebview = {
         tabId: tab.id,
-        routePath: normalizedRoutePath,
         webview: existingByLabel,
         ready: Promise.resolve(),
+        // Force one geometry sync because the native view can outlive a host
+        // component during HMR or development StrictMode probes.
+        bounds: { ...normalized, width: -1 },
       };
-
       managedWebviews.set(tab.id, reused);
-      await setWebviewBounds(existingByLabel, bounds);
+      await Promise.all([
+        updateManagedBounds(reused, normalized),
+        hideUnlessActive(reused),
+      ]);
       return reused;
     }
 
-    let targetUrl = "";
+    const routePath = normalizeWorkspaceRoutePath(tab.routePath);
+    let targetUrl: string;
 
     try {
-      targetUrl = toChildWebviewPath(normalizedRoutePath);
+      targetUrl = toChildWebviewPath(routePath);
     } catch (error) {
       console.error("Failed to resolve child webview URL", {
         tabId: tab.id,
-        routePath: normalizedRoutePath,
+        routePath,
         error,
       });
       return null;
     }
 
-    const normalized = normalizeBounds(bounds);
-    const appWindow = getCurrentWindow();
     let webview: Webview;
-    let alreadyExistsError = false;
-    let createErrorPayload = "";
-
     try {
-      webview = new Webview(appWindow, label, {
+      webview = new Webview(getCurrentWindow(), label, {
         url: targetUrl,
         x: normalized.x,
         y: normalized.y,
@@ -148,91 +156,75 @@ const ensureTabWebview = async (
       return null;
     }
 
-    let didFailToCreate = false;
-
+    let createError: unknown = null;
     const ready = new Promise<void>((resolve) => {
       let settled = false;
-
-      void webview.once("tauri://created", () => {
+      const finish = () => {
         if (settled) return;
         settled = true;
         resolve();
+      };
+
+      void webview.once("tauri://created", () => {
+        void hideUnlessActive({
+          tabId: tab.id,
+          webview,
+          ready: Promise.resolve(),
+          bounds: normalized,
+        }).finally(finish);
       });
 
       void webview.once("tauri://error", (event) => {
-        didFailToCreate = true;
-        const payload =
-          typeof event.payload === "string"
-            ? event.payload
-            : String(event.payload);
-        createErrorPayload = payload;
-        alreadyExistsError = payload.includes("already exists");
-        console.error("Child webview failed to initialize", {
-          tabId: tab.id,
-          targetUrl,
-          event,
-        });
-        if (settled) return;
-        settled = true;
-        resolve();
+        createError = event.payload;
+        finish();
       });
 
-      setTimeout(() => {
-        if (settled) return;
-        settled = true;
-        resolve();
-      }, 1200);
+      window.setTimeout(finish, CREATE_TIMEOUT_MS);
     });
 
     const created: ManagedWebview = {
       tabId: tab.id,
-      routePath: normalizedRoutePath,
       webview,
       ready,
+      bounds: normalized,
     };
-
     managedWebviews.set(tab.id, created);
+    await ready;
 
-    await created.ready;
-
-    if (didFailToCreate) {
-      if (alreadyExistsError) {
-        const recoveryWebview = await Webview.getByLabel(label);
-        if (recoveryWebview) {
-          const recovered: ManagedWebview = {
-            tabId: tab.id,
-            routePath: tab.routePath,
-            webview: recoveryWebview,
-            ready: Promise.resolve(),
-          };
-
-          managedWebviews.set(tab.id, recovered);
-          await setWebviewBounds(recoveryWebview, normalized);
-          return recovered;
-        }
-      }
-
-      if (createErrorPayload) {
-        console.error("Child webview create failure was not recoverable", {
+    if (createError !== null) {
+      const recovered = await Webview.getByLabel(label);
+      if (recovered) {
+        const entry: ManagedWebview = {
           tabId: tab.id,
-          label,
-          targetUrl,
-          createErrorPayload,
-        });
+          webview: recovered,
+          ready: Promise.resolve(),
+          bounds: normalized,
+        };
+        managedWebviews.set(tab.id, entry);
+        await hideUnlessActive(entry);
+        return entry;
       }
 
+      console.error("Child webview failed to initialize", {
+        tabId: tab.id,
+        targetUrl,
+        createError,
+      });
       await closeManagedWebview(created);
       managedWebviews.delete(tab.id);
       return null;
     }
 
-    await setWebviewBounds(webview, normalized);
+    if (!liveTabIds.has(tab.id)) {
+      await closeManagedWebview(created);
+      managedWebviews.delete(tab.id);
+      return null;
+    }
 
     return created;
   })();
 
   ensureInFlightByTabId.set(tab.id, task);
-
   try {
     return await task;
   } finally {
@@ -242,68 +234,78 @@ const ensureTabWebview = async (
   }
 };
 
-const syncTabWebviews = async (
+const activateTabWebview = async (tab: WorkspaceTab, bounds: HostBounds) => {
+  desiredActiveTabId = tab.id;
+  liveTabIds.add(tab.id);
+  const entry = await ensureTabWebview(tab, bounds);
+
+  if (!entry || desiredActiveTabId !== tab.id) return;
+
+  const previousEntry = visibleTabId ? managedWebviews.get(visibleTabId) : null;
+
+  // Reveal first so warm switches never expose the empty host between tabs.
+  await entry.webview.show();
+  visibleTabId = tab.id;
+  void entry.webview.setFocus();
+
+  if (previousEntry && previousEntry.tabId !== tab.id) {
+    void previousEntry.webview.hide();
+  }
+};
+
+const reconcileTabWebviews = async (
   tabs: WorkspaceTab[],
-  activeTabId: string,
   bounds: HostBounds,
 ) => {
-  const activeIds = new Set(tabs.map((tab) => tab.id));
+  liveTabIds = new Set(tabs.map((tab) => tab.id));
 
-  for (const [tabId, entry] of Array.from(managedWebviews.entries())) {
-    if (activeIds.has(tabId)) {
-      continue;
-    }
+  const staleEntries = Array.from(managedWebviews.entries()).filter(
+    ([tabId]) => !liveTabIds.has(tabId),
+  );
+  await Promise.all(
+    staleEntries.map(async ([tabId, entry]) => {
+      managedWebviews.delete(tabId);
+      if (visibleTabId === tabId) visibleTabId = null;
+      await closeManagedWebview(entry);
+    }),
+  );
 
-    await closeManagedWebview(entry);
-    managedWebviews.delete(tabId);
-  }
+  const activeTab = tabs.find((tab) => tab.id === desiredActiveTabId);
+  const backgroundTabs = tabs.filter((tab) => tab.id !== desiredActiveTabId);
 
-  for (const tab of tabs) {
-    await ensureTabWebview(tab, bounds);
-  }
+  if (activeTab) void activateTabWebview(activeTab, bounds);
 
-  for (const tab of tabs) {
-    const entry = managedWebviews.get(tab.id);
+  // Prewarm background tabs concurrently without blocking the selected tab.
+  await Promise.all(
+    backgroundTabs.map(async (tab) => {
+      const entry = await ensureTabWebview(tab, bounds);
+      if (entry) await hideUnlessActive(entry);
+    }),
+  );
+};
 
-    if (!entry) {
-      continue;
-    }
-
-    await entry.ready;
-    await setWebviewBounds(entry.webview, bounds);
-
-    if (tab.id === activeTabId) {
-      await Promise.allSettled([
-        entry.webview.show(),
-        entry.webview.setFocus(),
-      ]);
-      continue;
-    }
-
-    await Promise.allSettled([entry.webview.hide()]);
-  }
+const resizeManagedWebviews = async (bounds: HostBounds) => {
+  await Promise.all(
+    Array.from(managedWebviews.values()).map((entry) =>
+      updateManagedBounds(entry, bounds),
+    ),
+  );
 };
 
 const cleanupAllWebviews = async () => {
+  desiredActiveTabId = null;
+  visibleTabId = null;
+  liveTabIds.clear();
   ensureInFlightByTabId.clear();
-
-  for (const entry of Array.from(managedWebviews.values())) {
-    await closeManagedWebview(entry);
-  }
-
+  const entries = Array.from(managedWebviews.values());
   managedWebviews.clear();
+  await Promise.all(entries.map(closeManagedWebview));
 };
 
 const readHostBounds = (element: HTMLDivElement | null): HostBounds | null => {
-  if (!element) {
-    return null;
-  }
-
+  if (!element) return null;
   const rect = element.getBoundingClientRect();
-
-  if (rect.width <= 0 || rect.height <= 0) {
-    return null;
-  }
+  if (rect.width <= 0 || rect.height <= 0) return null;
 
   return {
     x: rect.left,
@@ -315,52 +317,83 @@ const readHostBounds = (element: HTMLDivElement | null): HostBounds | null => {
 
 export default function WebviewTabHost() {
   const hostRef = useRef<HTMLDivElement>(null);
-  const syncQueueRef = useRef<Promise<void>>(Promise.resolve());
   const tabs = useAppStore((state) => state.tabs);
   const activeTabId = useAppStore((state) => state.activeTabId);
   const [bounds, setBounds] = useState<HostBounds | null>(null);
+  const tabsRef = useRef(tabs);
+  const boundsRef = useRef(bounds);
+  tabsRef.current = tabs;
+  boundsRef.current = bounds;
+
+  const tabIdSignature = useMemo(
+    () => tabs.map((tab) => tab.id).join("\u0000"),
+    [tabs],
+  );
+  const hasBounds = bounds !== null;
 
   useEffect(() => {
     const host = hostRef.current;
+    if (!host) return;
 
-    if (!host) {
-      return;
-    }
-
+    let animationFrame: number | null = null;
     const updateBounds = () => {
-      setBounds(readHostBounds(host));
+      if (animationFrame !== null) return;
+      animationFrame = window.requestAnimationFrame(() => {
+        animationFrame = null;
+        const nextBounds = readHostBounds(host);
+        setBounds((current) =>
+          current && nextBounds && areSameBounds(current, nextBounds)
+            ? current
+            : nextBounds,
+        );
+      });
     };
 
     updateBounds();
-
-    const observer = new ResizeObserver(() => {
-      updateBounds();
-    });
-
+    const observer = new ResizeObserver(updateBounds);
     observer.observe(host);
     window.addEventListener("resize", updateBounds);
 
     return () => {
+      if (animationFrame !== null) window.cancelAnimationFrame(animationFrame);
       observer.disconnect();
       window.removeEventListener("resize", updateBounds);
     };
   }, []);
 
   useEffect(() => {
-    if (!bounds || !activeTabId || tabs.length === 0) {
-      return;
+    desiredActiveTabId = activeTabId;
+    const currentBounds = boundsRef.current;
+    const activeTab = tabsRef.current.find((tab) => tab.id === activeTabId);
+    if (currentBounds && activeTab) {
+      void activateTabWebview(activeTab, currentBounds);
     }
-
-    syncQueueRef.current = syncQueueRef.current
-      .catch(() => {
-        // Keep queue alive even if previous cycle failed.
-      })
-      .then(() => syncTabWebviews(tabs, activeTabId, bounds));
-  }, [activeTabId, bounds, tabs]);
+  }, [activeTabId, hasBounds]);
 
   useEffect(() => {
+    const currentBounds = boundsRef.current;
+    if (currentBounds) {
+      void reconcileTabWebviews(tabsRef.current, currentBounds);
+    }
+  }, [tabIdSignature, hasBounds]);
+
+  useEffect(() => {
+    if (bounds) void resizeManagedWebviews(bounds);
+  }, [bounds]);
+
+  useEffect(() => {
+    if (pendingCleanupTimer !== null) {
+      window.clearTimeout(pendingCleanupTimer);
+      pendingCleanupTimer = null;
+    }
+
     return () => {
-      void cleanupAllWebviews();
+      // StrictMode immediately remounts effects in development. Delaying this
+      // prevents its probe from destroying the persistent child surfaces.
+      pendingCleanupTimer = window.setTimeout(() => {
+        pendingCleanupTimer = null;
+        void cleanupAllWebviews();
+      }, 0);
     };
   }, []);
 

--- a/apps/desktop/src/lib/tab-switching.ts
+++ b/apps/desktop/src/lib/tab-switching.ts
@@ -5,6 +5,48 @@ export const TAB_SWITCH_CYCLE_MODE: TabSwitchCycleMode = "Sequential";
 
 export const TAB_SWITCH_SHORTCUT_EVENT = "gitru:tab-switch-shortcut";
 
+export type TabManagementShortcut = "create" | "close";
+export type TabManagementShortcutModifier = "Control" | "Meta";
+
+type TabManagementKeyboardEvent = Pick<
+  KeyboardEvent,
+  "altKey" | "ctrlKey" | "key" | "metaKey" | "repeat" | "shiftKey"
+>;
+
+const getPlatformShortcutModifier = (): TabManagementShortcutModifier =>
+  typeof navigator !== "undefined" &&
+  /Mac|iPhone|iPad|iPod/i.test(navigator.platform)
+    ? "Meta"
+    : "Control";
+
+export const resolveTabManagementShortcut = (
+  {
+    altKey,
+    ctrlKey,
+    key,
+    metaKey,
+    repeat,
+    shiftKey,
+  }: TabManagementKeyboardEvent,
+  shortcutModifier = getPlatformShortcutModifier(),
+): TabManagementShortcut | null => {
+  const hasShortcutModifier =
+    shortcutModifier === "Meta" ? metaKey && !ctrlKey : ctrlKey && !metaKey;
+
+  if (!hasShortcutModifier || altKey || shiftKey || repeat) {
+    return null;
+  }
+
+  switch (key.toLowerCase()) {
+    case "t":
+      return "create";
+    case "w":
+      return "close";
+    default:
+      return null;
+  }
+};
+
 export type TabSwitchShortcutPayload =
   | {
       phase: "advance";
@@ -13,4 +55,7 @@ export type TabSwitchShortcutPayload =
     }
   | {
       phase: "commit";
+    }
+  | {
+      phase: TabManagementShortcut;
     };

--- a/apps/desktop/tests/tab-shortcuts.test.ts
+++ b/apps/desktop/tests/tab-shortcuts.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import { resolveTabManagementShortcut } from "../src/lib/tab-switching";
+
+const keyboardEvent = (
+  overrides: Partial<Parameters<typeof resolveTabManagementShortcut>[0]> = {},
+) => ({
+  altKey: false,
+  ctrlKey: false,
+  key: "",
+  metaKey: false,
+  repeat: false,
+  shiftKey: false,
+  ...overrides,
+});
+
+describe("resolveTabManagementShortcut", () => {
+  test("creates a tab with Command+T or Control+T", () => {
+    expect(
+      resolveTabManagementShortcut(
+        keyboardEvent({ key: "t", metaKey: true }),
+        "Meta",
+      ),
+    ).toBe("create");
+    expect(
+      resolveTabManagementShortcut(
+        keyboardEvent({ ctrlKey: true, key: "T" }),
+        "Control",
+      ),
+    ).toBe("create");
+  });
+
+  test("closes a tab with Command+W or Control+W", () => {
+    expect(
+      resolveTabManagementShortcut(
+        keyboardEvent({ key: "w", metaKey: true }),
+        "Meta",
+      ),
+    ).toBe("close");
+    expect(
+      resolveTabManagementShortcut(
+        keyboardEvent({ ctrlKey: true, key: "W" }),
+        "Control",
+      ),
+    ).toBe("close");
+  });
+
+  test("uses Command on Apple platforms and Control elsewhere", () => {
+    expect(
+      resolveTabManagementShortcut(
+        keyboardEvent({ ctrlKey: true, key: "w" }),
+        "Meta",
+      ),
+    ).toBe(null);
+    expect(
+      resolveTabManagementShortcut(
+        keyboardEvent({ key: "t", metaKey: true }),
+        "Control",
+      ),
+    ).toBe(null);
+  });
+
+  test("ignores unmodified and unrelated keys", () => {
+    expect(
+      resolveTabManagementShortcut(keyboardEvent({ key: "t" }), "Meta"),
+    ).toBe(null);
+    expect(
+      resolveTabManagementShortcut(
+        keyboardEvent({ key: "p", metaKey: true }),
+        "Meta",
+      ),
+    ).toBe(null);
+  });
+
+  test("preserves shifted and alternate shortcut combinations", () => {
+    expect(
+      resolveTabManagementShortcut(
+        keyboardEvent({ key: "t", metaKey: true, shiftKey: true }),
+        "Meta",
+      ),
+    ).toBe(null);
+    expect(
+      resolveTabManagementShortcut(
+        keyboardEvent({ altKey: true, ctrlKey: true, key: "w" }),
+        "Control",
+      ),
+    ).toBe(null);
+  });
+
+  test("ignores repeated keydown events", () => {
+    expect(
+      resolveTabManagementShortcut(
+        keyboardEvent({ key: "t", metaKey: true, repeat: true }),
+        "Meta",
+      ),
+    ).toBe(null);
+    expect(
+      resolveTabManagementShortcut(
+        keyboardEvent({ ctrlKey: true, key: "w", repeat: true }),
+        "Control",
+      ),
+    ).toBe(null);
+  });
+});

--- a/apps/desktop/tests/tab-strip-layout.test.ts
+++ b/apps/desktop/tests/tab-strip-layout.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { resolveTabStripLayout } from "../src/components/custom-title-bar/tab-strip-layout";
+
+describe("resolveTabStripLayout", () => {
+  test("keeps sparse tabs at their preferred width", () => {
+    expect(
+      resolveTabStripLayout({
+        containerWidth: 800,
+        controlsWidth: 38,
+        tabCount: 2,
+      }),
+    ).toEqual({ railWidth: 484, tabWidth: 240 });
+  });
+
+  test("shares constrained space evenly between tabs", () => {
+    expect(
+      resolveTabStripLayout({
+        containerWidth: 642,
+        controlsWidth: 38,
+        tabCount: 4,
+      }),
+    ).toEqual({ railWidth: 600, tabWidth: 147 });
+  });
+
+  test("never produces negative widths in extremely tight space", () => {
+    expect(
+      resolveTabStripLayout({
+        containerWidth: 20,
+        controlsWidth: 38,
+        tabCount: 12,
+      }),
+    ).toEqual({ railWidth: 0, tabWidth: 0 });
+  });
+
+  test("returns an empty rail when there are no tabs", () => {
+    expect(
+      resolveTabStripLayout({
+        containerWidth: 800,
+        controlsWidth: 38,
+        tabCount: 0,
+      }),
+    ).toEqual({ railWidth: 0, tabWidth: 0 });
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,7 +37,8 @@
     "scroll-into-view-if-needed": "^3.1.0",
     "shadcn": "^4.0.2",
     "tailwind-merge": "^3.5.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@gitru/mascot": "*",

--- a/bun.lock
+++ b/bun.lock
@@ -130,6 +130,7 @@
         "shadcn": "^4.0.2",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
+        "zod": "catalog:",
       },
       "devDependencies": {
         "@gitru/mascot": "*",


### PR DESCRIPTION
## Summary

- bypass the serialized reconciliation queue for warm tab activation
- prewarm persistent background webviews concurrently
- separate and deduplicate native webview geometry updates
- guard cold activation and StrictMode cleanup races

## Tradeoff

Each warm tab retains its WKWebView, improving switching latency at the cost of memory that grows with the number of open tabs. A production follow-up should add an LRU or suspension policy.

## Validation

- `bun --cwd=./apps/desktop run check-types`
- `bunx biome check apps/desktop/src/components/webview-tab-host.tsx`
- `git diff --check`
- `bun test apps/desktop/tests` (8 passed)
- Tauri debug macOS application bundle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added native application menus for creating and closing tabs and windows.
  - Added keyboard shortcuts for creating and closing tabs.
  - Tabs can now be closed with the middle mouse button.

- **Performance**
  - Improved webview reuse, background tab preparation, resizing, and switching responsiveness.

- **Bug Fixes**
  - Improved recovery from loading timeouts and initialization errors.
  - Reduced tab flicker and improved cleanup during navigation and app reloads.

- **UI Improvements**
  - Improved title bar and compact tab layouts, including responsive close-button behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->